### PR TITLE
YouTube 動画が画面サイズより大きいときに縦横比が正しく表示されないバグを修正

### DIFF
--- a/node/__tests__/MessageParser.test.js
+++ b/node/__tests__/MessageParser.test.js
@@ -350,7 +350,7 @@ code
 !youtube:HJxspEKHqCs 560x315 caption
 `)
 		).toBe(
-			'<div class="c-flex"><figure class="c-flex__item"><div class="p-embed"><iframe src="https://www.youtube-nocookie.com/embed/HJxspEKHqCs?rel=0" title="YouTube 動画" width="560" height="315" class="p-embed__frame" style="--aspect-ratio:560/315"></iframe></div><figcaption class="c-caption"><span class="c-caption__no">動画1</span><span class="c-caption__title"><a href="https://www.youtube.com/watch?v=HJxspEKHqCs">caption</a><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon"></span></figcaption></figure></div>'
+			'<figure><div class="p-embed"><iframe src="https://www.youtube-nocookie.com/embed/HJxspEKHqCs?rel=0" title="YouTube 動画" width="560" height="315" class="p-embed__frame" style="--aspect-ratio:560/315"></iframe></div><figcaption class="c-caption"><span class="c-caption__no">動画1</span><span class="c-caption__title"><a href="https://www.youtube.com/watch?v=HJxspEKHqCs">caption</a><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon"></span></figcaption></figure>'
 		);
 	});
 

--- a/node/src/util/MessageParser.ts
+++ b/node/src/util/MessageParser.ts
@@ -1193,17 +1193,8 @@ export default class MessageParser {
 	 * @param {string} caption - タイトル
 	 */
 	#appendYouTube(id: string, width: number, height: number, caption: string): void {
-		if (!this.#media || this.#mediaWrapElement === undefined) {
-			const gridElement = this.#document.createElement('div');
-			gridElement.className = 'c-flex';
-			this.#appendChild(gridElement);
-
-			this.#mediaWrapElement = gridElement;
-		}
-
 		const figureElement = this.#document.createElement('figure');
-		figureElement.className = 'c-flex__item';
-		this.#mediaWrapElement.appendChild(figureElement);
+		this.#appendChild(figureElement);
 
 		const embeddElement = this.#document.createElement('div');
 		embeddElement.className = 'p-embed';

--- a/public/style/_src/object/project/_main-embedded.css
+++ b/public/style/_src/object/project/_main-embedded.css
@@ -68,6 +68,7 @@
 	border: var(--_border-width) solid var(--color-black);
 	aspect-ratio: var(--aspect-ratio, auto);
 	inline-size: 100%;
+	block-size: auto;
 }
 
 .p-embed__tweet {


### PR DESCRIPTION
あわせて動画を横並びにさせる必要はないため flex による横並びをやめる