### PR TITLE
インライン引用のフォーマットを `{{URL テキスト}}` から `{{テキスト}}(URL)` に変更

### DIFF
--- a/node/__tests__/MessageParser.test.js
+++ b/node/__tests__/MessageParser.test.js
@@ -537,20 +537,38 @@ describe('inline', () => {
 	});
 
 	test('quote - cite - URL', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text{{https://example.com/ quote<s>quote</s>}}text')).toBe(
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text{{quote<s>quote</s>}}(https://example.com/)text')).toBe(
 			'<p>text<a href="https://example.com/"><q class="c-quote" cite="https://example.com/">quote&lt;s&gt;quote&lt;/s&gt;</q></a>text</p>'
 		);
 	});
 
 	test('quote - cite - ISBN', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text{{978-4-06-519981-7 quote<s>quote</s>}}text')).toBe(
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text{{quote<s>quote</s>}}(978-4-06-519981-7)text')).toBe(
 			'<p>text<q class="c-quote" cite="urn:ISBN:978-4-06-519981-7">quote&lt;s&gt;quote&lt;/s&gt;</q>text</p>'
 		);
 	});
 
 	test('quote - cite - ISBN - invalid check digit', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text{{978-4-06-519981-0 quote<s>quote</s>}}text')).toBe(
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text{{quote<s>quote</s>}}(978-4-06-519981-0)text')).toBe(
 			'<p>text<q class="c-quote">quote&lt;s&gt;quote&lt;/s&gt;</q>text</p>'
+		);
+	});
+
+	test('quote - cite - lang', async () => {
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text{{quote<s>quote</s>}}(en)text')).toBe(
+			'<p>text<q class="c-quote" lang="en">quote&lt;s&gt;quote&lt;/s&gt;</q>text</p>'
+		);
+	});
+
+	test('quote - cite - URL & ISBN & lang', async () => {
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text{{quote<s>quote</s>}}(https://example.com/ 978-4-06-519981-7 en)text')).toBe(
+			'<p>text<a href="https://example.com/"><q class="c-quote" lang="en" cite="https://example.com/">quote&lt;s&gt;quote&lt;/s&gt;</q></a>text</p>'
+		);
+	});
+
+	test('quote - cite - empty', async () => {
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text{{quote<s>quote</s>}}()text')).toBe(
+			'<p>text<q class="c-quote">quote&lt;s&gt;quote&lt;/s&gt;</q>()text</p>'
 		);
 	});
 

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -390,7 +390,7 @@
 									<td>記事内リンク（<code class="c-code">a</code>）</td>
 								</tr>
 								<tr>
-									<th scope="row">[リンク名](絶対URL)</th>
+									<th scope="row">[リンク名](URL)</th>
 									<td>外部サイトリンク（<code class="c-code">a</code>）</td>
 								</tr>
 								<tr>
@@ -406,7 +406,7 @@
 									<td>コード（<code class="c-code">code</code>）</td>
 								</tr>
 								<tr>
-									<th scope="row">{{出典URI<b class="u-red">␣</b>引用文}}</th>
+									<th scope="row">{{引用文}}(URL<b class="u-red">?␣</b>ISBN<b class="u-red">?␣</b>言語<b class="u-red">?</b>)</th>
 									<td>インラインレベルの引用（<code class="c-code">q</code>）</td>
 								</tr>
 								<tr>


### PR DESCRIPTION
合わせて `lang` 属性に対応する