### PR TITLE
インラインリンクの前後の要素のエスケープがされていなかったバグを修正

### DIFF
--- a/node/__tests__/MessageParser.test.js
+++ b/node/__tests__/MessageParser.test.js
@@ -420,20 +420,20 @@ describe('inline', () => {
 	});
 
 	test('link - URL', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text[link<s>link</s>](https://example.com/)text')).toBe(
-			'<p>text<a href="https://example.com/">link&lt;s&gt;link&lt;/s&gt;</a><b class="c-domain">(example.com)</b>text</p>'
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('<s>text</s>[link<s>link</s>](https://example.com/)<s>text</s>')).toBe(
+			'<p>&lt;s&gt;text&lt;/s&gt;<a href="https://example.com/">link&lt;s&gt;link&lt;/s&gt;</a><b class="c-domain">(example.com)</b>&lt;s&gt;text&lt;/s&gt;</p>'
 		);
 	});
 
 	test('link - URL - URL text', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text[https://example.com/](https://example.com/)text')).toBe(
-			'<p>text<a href="https://example.com/">https://example.com/</a>text</p>'
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('<s>text</s>[https://example.com/](https://example.com/)<s>text</s>')).toBe(
+			'<p>&lt;s&gt;text&lt;/s&gt;<a href="https://example.com/">https://example.com/</a>&lt;s&gt;text&lt;/s&gt;</p>'
 		);
 	});
 
 	test('link - URL - PDF', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text[link<s>link</s>](https://example.com/foo.pdf)text')).toBe(
-			'<p>text<a href="https://example.com/foo.pdf" type="application/pdf">link&lt;s&gt;link&lt;/s&gt;</a><img src="/image/icon/pdf.png" alt="(PDF)" width="16" height="16" class="c-link-icon"><b class="c-domain">(example.com)</b>text</p>'
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('<s>text</s>[link<s>link</s>](https://example.com/foo.pdf)<s>text</s>')).toBe(
+			'<p>&lt;s&gt;text&lt;/s&gt;<a href="https://example.com/foo.pdf" type="application/pdf">link&lt;s&gt;link&lt;/s&gt;</a><img src="/image/icon/pdf.png" alt="(PDF)" width="16" height="16" class="c-link-icon"><b class="c-domain">(example.com)</b>&lt;s&gt;text&lt;/s&gt;</p>'
 		);
 	});
 
@@ -448,67 +448,73 @@ describe('inline', () => {
 						src: '/example.svg',
 					},
 				],
-			}).toHtml('text[link<s>link</s>](https://example.com/)text')
+			}).toHtml('<s>text</s>[link<s>link</s>](https://example.com/)<s>text</s>')
 		).toBe(
-			'<p>text<a href="https://example.com/">link&lt;s&gt;link&lt;/s&gt;</a><img src="/example.svg" alt="(Example)" width="16" height="16" class="c-link-icon">text</p>'
+			'<p>&lt;s&gt;text&lt;/s&gt;<a href="https://example.com/">link&lt;s&gt;link&lt;/s&gt;</a><img src="/example.svg" alt="(Example)" width="16" height="16" class="c-link-icon">&lt;s&gt;text&lt;/s&gt;</p>'
 		);
 	});
 
 	test('link - entry ID', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text[link<s>link</s>](1)text')).toBe(
-			'<p>text<a href="/1">link&lt;s&gt;link&lt;/s&gt;</a>text</p>'
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('<s>text</s>[link<s>link</s>](1)<s>text</s>')).toBe(
+			'<p>&lt;s&gt;text&lt;/s&gt;<a href="/1">link&lt;s&gt;link&lt;/s&gt;</a>&lt;s&gt;text&lt;/s&gt;</p>'
 		);
 	});
 
 	test('link - amazon', async () => {
-		expect(await new MessageParser(config, { dbh: dbh, amazon_tracking_id: 'xxx-22' }).toHtml('text[link<s>link</s>](amazon:4065199816)text')).toBe(
-			'<p>text<a href="https://www.amazon.co.jp/dp/4065199816/ref=nosim?tag=xxx-22">link&lt;s&gt;link&lt;/s&gt;</a><img src="/image/icon/amazon.png" alt="(Amazon)" width="16" height="16" class="c-link-icon">text</p>'
+		expect(
+			await new MessageParser(config, { dbh: dbh, amazon_tracking_id: 'xxx-22' }).toHtml('<s>text</s>[link<s>link</s>](amazon:4065199816)<s>text</s>')
+		).toBe(
+			'<p>&lt;s&gt;text&lt;/s&gt;<a href="https://www.amazon.co.jp/dp/4065199816/ref=nosim?tag=xxx-22">link&lt;s&gt;link&lt;/s&gt;</a><img src="/image/icon/amazon.png" alt="(Amazon)" width="16" height="16" class="c-link-icon">&lt;s&gt;text&lt;/s&gt;</p>'
 		);
 	});
 
 	test('link - #section', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text[link<s>link</s>](#section-1)text')).toBe(
-			'<p>text<a href="#section-1">link&lt;s&gt;link&lt;/s&gt;</a>text</p>'
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('<s>text</s>[link<s>link</s>](#section-1)<s>text</s>')).toBe(
+			'<p>&lt;s&gt;text&lt;/s&gt;<a href="#section-1">link&lt;s&gt;link&lt;/s&gt;</a>&lt;s&gt;text&lt;/s&gt;</p>'
 		);
 	});
 
 	test('link - invalid', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text[link<s>link</s>](foo)text')).toBe('<p>text[link&lt;s&gt;link&lt;/s&gt;](foo)text</p>');
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('<s>text</s>[link<s>link</s>](foo)<s>text</s>')).toBe(
+			'<p>&lt;s&gt;text&lt;/s&gt;[link&lt;s&gt;link&lt;/s&gt;](foo)&lt;s&gt;text&lt;/s&gt;</p>'
+		);
 	});
 
 	test('link - multi', async () => {
 		expect(
-			await new MessageParser(config, { dbh: dbh }).toHtml('text[link<s>link</s>](https://example.com/)text[link<s>link</s>](https://example.com/)text')
+			await new MessageParser(config, { dbh: dbh }).toHtml(
+				'<s>text</s>[link<s>link</s>](https://example.com/)<s>text</s>[link<s>link</s>](https://example.com/)<s>text</s>'
+			)
 		).toBe(
-			'<p>text<a href="https://example.com/">link&lt;s&gt;link&lt;/s&gt;</a><b class="c-domain">(example.com)</b>text<a href="https://example.com/">link&lt;s&gt;link&lt;/s&gt;</a><b class="c-domain">(example.com)</b>text</p>'
+			'<p>&lt;s&gt;text&lt;/s&gt;<a href="https://example.com/">link&lt;s&gt;link&lt;/s&gt;</a><b class="c-domain">(example.com)</b>&lt;s&gt;text&lt;/s&gt;<a href="https://example.com/">link&lt;s&gt;link&lt;/s&gt;</a><b class="c-domain">(example.com)</b>&lt;s&gt;text&lt;/s&gt;</p>'
 		);
 	});
 
 	test('link - text[', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text[link[link](https://example.com/)text')).toBe(
-			'<p>text[link<a href="https://example.com/">link</a><b class="c-domain">(example.com)</b>text</p>'
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('<s>text</s>[link[link](https://example.com/)<s>text</s>')).toBe(
+			'<p>&lt;s&gt;text&lt;/s&gt;[link<a href="https://example.com/">link</a><b class="c-domain">(example.com)</b>&lt;s&gt;text&lt;/s&gt;</p>'
 		);
 	});
 
 	test('link - text]', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text[link]link](https://example.com/)text')).toBe(
-			'<p>text<a href="https://example.com/">link]link</a><b class="c-domain">(example.com)</b>text</p>'
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('<s>text</s>[link]link](https://example.com/)<s>text</s>')).toBe(
+			'<p>&lt;s&gt;text&lt;/s&gt;<a href="https://example.com/">link]link</a><b class="c-domain">(example.com)</b>&lt;s&gt;text&lt;/s&gt;</p>'
 		);
 	});
 
 	test('link - text[]', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text[link[link]link](https://example.com/)text')).toBe(
-			'<p>text<a href="https://example.com/">link[link]link</a><b class="c-domain">(example.com)</b>text</p>'
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('<s>text</s>[link[link]link](https://example.com/)<s>text</s>')).toBe(
+			'<p>&lt;s&gt;text&lt;/s&gt;<a href="https://example.com/">link[link]link</a><b class="c-domain">(example.com)</b>&lt;s&gt;text&lt;/s&gt;</p>'
 		);
 	});
 
 	test('link - feint1', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text[text')).toBe('<p>text[text</p>');
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('<s>text</s>[<s>text</s>')).toBe('<p>&lt;s&gt;text&lt;/s&gt;[&lt;s&gt;text&lt;/s&gt;</p>');
 	});
 
 	test('link - feint2', async () => {
-		expect(await new MessageParser(config, { dbh: dbh }).toHtml('text[link](https://example.com/)text[text')).toBe(
-			'<p>text<a href="https://example.com/">link</a><b class="c-domain">(example.com)</b>text[text</p>'
+		expect(await new MessageParser(config, { dbh: dbh }).toHtml('<s>text</s>[link](https://example.com/)text[<s>text</s>')).toBe(
+			'<p>&lt;s&gt;text&lt;/s&gt;<a href="https://example.com/">link</a><b class="c-domain">(example.com)</b>text[&lt;s&gt;text&lt;/s&gt;</p>'
 		);
 	});
 

--- a/node/src/util/MessageParser.ts
+++ b/node/src/util/MessageParser.ts
@@ -1570,7 +1570,7 @@ export default class MessageParser {
 				}
 
 				let parseTargetText = htmlFragment; // パース対象の文字列
-				const parsedTextList: string[] = []; // パース後の文字列を格納する配列
+				const parsedTextList_htmlescaped: string[] = []; // パース後の文字列を格納する配列
 				let afterLinkText = '';
 
 				while (openingTextDelimiterIndex !== -1) {
@@ -1581,7 +1581,7 @@ export default class MessageParser {
 
 					/* [ が出現したが、 [TEXT](URL) の構文になっていない場合 */
 					if (matchGroups === undefined) {
-						if (parsedTextList.length === 0) {
+						if (parsedTextList_htmlescaped.length === 0) {
 							return htmlFragment_htmlescaped;
 						}
 						break;
@@ -1614,9 +1614,9 @@ export default class MessageParser {
 					linkText = scanText + tempLinkText;
 
 					/* HTML 文字列に変換 */
-					let linkHtml = '';
+					let anchor_htmlescaped = '';
 					try {
-						linkHtml = ((): string => {
+						anchor_htmlescaped = ((): string => {
 							/* 絶対 URL */
 							const absoluteUrlMatchGroups = url.match(new RegExp(`^(?<absoluteUrl>${this.#REGEXP_ABSOLUTE_URL})$`))?.groups;
 							if (absoluteUrlMatchGroups !== undefined) {
@@ -1676,13 +1676,13 @@ export default class MessageParser {
 					}
 
 					/* 後処理 */
-					parsedTextList.push(`${beforeOpeningTextDelimiterText}${linkHtml}`);
+					parsedTextList_htmlescaped.push(`${StringEscapeHtml.escape(beforeOpeningTextDelimiterText)}${anchor_htmlescaped}`);
 					parseTargetText = afterLinkText;
 
 					openingTextDelimiterIndex = parseTargetText.indexOf('[');
 				}
 
-				return `${parsedTextList.join('')}${afterLinkText}`;
+				return `${parsedTextList_htmlescaped.join('')}${StringEscapeHtml.escape(afterLinkText)}`;
 			})();
 		}
 


### PR DESCRIPTION
`<s> [link](1)` の時、 `<s>` がエスケープされずそのまま出力されていた