### PR TITLE
リンク付きインライン引用にも `type` やホスト情報を設定

### DIFF
--- a/node/src/util/MessageParser.ts
+++ b/node/src/util/MessageParser.ts
@@ -1750,7 +1750,9 @@ export default class MessageParser {
 								qAttr += ` ${name}=${value}`;
 							}
 
-							return StringEscapeHtml.template`<a href="${url}"><q class="c-quote"${qAttr}>${quote}</q></a>`;
+							return this.#anchor(quote, url)
+								.replace(/^<a (?<attr>.+?)>/, `<a $<attr>><q${qAttr}>`)
+								.replace('</a>', '</q></a>');
 						} else if (isbn !== undefined) {
 							if (new IsbnVerify(isbn, { strict: true }).isValid()) {
 								qAttributeMap.set('cite', `urn:ISBN:${isbn}`);


### PR DESCRIPTION
通常の `<a href>` の処理と共通化し、 `type` 属性とホスト情報の付与を行うようにする