### PR TITLE
画像、動画のキャプションに `<code>` を使えるようにする

### DIFF
--- a/node/src/util/MessageParser.ts
+++ b/node/src/util/MessageParser.ts
@@ -1150,7 +1150,7 @@ export default class MessageParser {
 
 				const captionTitleElement = this.#document.createElement('span');
 				captionTitleElement.className = 'c-caption__title';
-				captionTitleElement.textContent = caption;
+				this.#inlineMarkup(captionTitleElement, caption, { code: true });
 				figcaptionElement.appendChild(captionTitleElement);
 
 				this.#imageNum += 1;
@@ -1175,7 +1175,7 @@ export default class MessageParser {
 
 				const captionTitleElement = this.#document.createElement('span');
 				captionTitleElement.className = 'c-caption__title';
-				captionTitleElement.textContent = caption;
+				this.#inlineMarkup(captionTitleElement, caption, { code: true });
 				figcaptionElement.appendChild(captionTitleElement);
 
 				this.#videoNum += 1;


### PR DESCRIPTION
現時点で以下2記事で使用

- [入力キャレットの色を変える `caret-color` プロパティ（CSS3 UI）](https://blog.w0s.jp/567)
- [表のキャプションは `<caption>` か `<figcaption>` か](https://blog.w0s.jp/672)
