### PR TITLE
別言語のソースを引用時、 `<a hreflang>`の属性指定を取り止める

### DIFF
--- a/node/__tests__/MessageParser.test.js
+++ b/node/__tests__/MessageParser.test.js
@@ -136,7 +136,7 @@ text2
 ?https://example.com/foo.pdf
 `)
 		).toBe(
-			'<figure><blockquote class="p-quote" lang="en" cite="https://example.com/foo.pdf"><p>text1</p><p>text2</p></blockquote><figcaption class="c-caption -meta"><span class="c-caption__title"><a href="https://example.com/foo.pdf" hreflang="en" type="application/pdf">cite</a><img src="/image/icon/pdf.png" alt="(PDF)" width="16" height="16" class="c-link-icon"><b class="c-domain">(example.com)</b></span></figcaption></figure>'
+			'<figure><blockquote class="p-quote" lang="en" cite="https://example.com/foo.pdf"><p>text1</p><p>text2</p></blockquote><figcaption class="c-caption -meta"><span class="c-caption__title"><a href="https://example.com/foo.pdf" type="application/pdf">cite</a><img src="/image/icon/pdf.png" alt="(PDF)" width="16" height="16" class="c-link-icon"><b class="c-domain">(example.com)</b></span></figcaption></figure>'
 		);
 	});
 

--- a/node/src/util/MessageParser.ts
+++ b/node/src/util/MessageParser.ts
@@ -90,7 +90,6 @@ export default class MessageParser {
 	#quoteCite = false;
 	#quoteTitle: string | undefined; // 引用元タイトル
 	#quoteUrl: URL | undefined; // 引用元 URL
-	#quoteLanguage: string | undefined; // 引用文の言語
 
 	/* コード */
 	#code = false;
@@ -227,7 +226,6 @@ export default class MessageParser {
 
 				this.#quoteTitle = undefined;
 				this.#quoteUrl = undefined;
-				this.#quoteLanguage = undefined;
 			}
 
 			if (!this.#thead && !this.#tbody) {
@@ -405,7 +403,6 @@ export default class MessageParser {
 						} else if (new RegExp(`^${this.#config.regexp['lang']}$`).test(metaText)) {
 							/* 言語 */
 							this.#quoteElement.setAttribute('lang', metaText);
-							this.#quoteLanguage = metaText;
 						} else {
 							this.#quoteTitle = metaText;
 						}
@@ -901,7 +898,7 @@ export default class MessageParser {
 		if (this.#quoteUrl === undefined) {
 			captionTitleElement.textContent = this.#quoteTitle;
 		} else {
-			captionTitleElement.insertAdjacentHTML('beforeend', this.#inline.anchor(this.#quoteTitle, this.#quoteUrl.toString(), { hreflang: this.#quoteLanguage }));
+			captionTitleElement.insertAdjacentHTML('beforeend', this.#inline.anchor(this.#quoteTitle, this.#quoteUrl.toString()));
 		}
 	}
 


### PR DESCRIPTION
`<blockquote lang>` と `<a hreflang>` をセットで指定していたが、引用元のページ全体の言語と引用該当部分の言語が違うケースも考えられるので、言語は `<blockquote lang>` のみで表現することにする