### PR TITLE
`.c-entry-link` の `@container` を `@media` に戻す

### DIFF
--- a/public/style/_src/object/component/_grouping.css
+++ b/public/style/_src/object/component/_grouping.css
@@ -13,7 +13,6 @@
 
 	display: flow-root; /* for Safari */
 	contain: layout;
-	container-type: inline-size;
 	font-size: calc(100% * var(--_title-font-expand-ratio));
 	line-height: var(--line-height-narrow);
 
@@ -48,7 +47,8 @@
 	pointer-events: none;
 }
 
-@container (inline-size <= 24em) {
+@media (width <= 36em) {
+	/* @container は Chrome で効かない https://github.com/SaekiTominaga/blog.w0s.jp/pull/219 */
 	.c-entry-link {
 		margin-inline-start: calc(var(--_bullet-inline-size) + var(--_bullet-gap));
 	}


### PR DESCRIPTION
1. #214 で Container Queries を導入した
1. `.c-entry-link` 部分のみ、Chrome で適用されないバグがあったので、 #218 で修正した

しかし、今度は Firefox 110 ～ 112 Nightly にて、なぜか `.l-content` が右寄せになる現象となってしまった。
ちなみに `.l-content` は `.c-entry-link` を除き、 `container-type: inline-size` を設定している直近の祖先要素である。
解決方法が分からないため、やむなく `@media` に戻す

![Screenshot 2023-03-06 at 23-23-52 富永日記帳](https://user-images.githubusercontent.com/4138486/223137348-2a9838bc-f446-4496-8530-1997739590b2.png)
