### PR TITLE
`.c-entry-link` で画像が右側に表示されるとき、 `.p-title-list >li` の `border` が短くなるバグを修正

### DIFF
--- a/public/style/_src/object/project/_main.css
+++ b/public/style/_src/object/project/_main.css
@@ -243,7 +243,7 @@
 /* ===== 記事タイトルリスト ===== */
 .p-title-list {
 	& > li {
-		padding-block: 1em;
+		padding-block: 1.5em;
 
 		@media (--breakpoint) {
 			padding-inline: var(--page-padding-inline);

--- a/views/category.ejs
+++ b/views/category.ejs
@@ -29,36 +29,38 @@
 				<main class="l-content__main">
 					<ul class="p-title-list -category">
 						<%_ for (const entry of entries) { _%>
-						<li class="c-entry-link">
-							<a href="/<%= entry.id %>">
-								<span class="c-entry-link__thumb">
-									<%_ if (entry.image_internal !== null) { _%>
-									<picture>
-										<source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=avif;w=180;h=180;quality=60, https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=avif;w=360;h=360;quality=30 2x" />
-										<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=webp;w=180;h=180;quality=60, https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=webp;w=360;h=360;quality=30 2x" />
-										<img src="https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=jpeg;w=180;h=180;quality=60" alt="" class="c-entry-link__image" />
-									</picture>
-									<%_ } else if (entry.image_external !== null) { _%>
-									<img src="<%= entry.image_external %>" alt="" class="c-entry-link__image" />
-									<%_ } else { _%>
-									<img src="/image/noimage.svg" alt="" width="180" height="120" class="c-entry-link__image" />
-									<%_ } _%>
-								</span>
-								<span class="c-entry-link__title"><%- entry.title %></span>
-							</a>
-							<div class="c-entry-link__date">
-								<dl class="c-entry-meta">
-									<div class="c-entry-meta__group">
-										<dt>投稿</dt>
-										<dd><time datetime="<%= entry.created.format('YYYY-MM-DDTHH:mm:ssZ') %>"><%= entry.created.format('YYYY年M月D日') %></time></dd>
-									</div>
-									<%_ if (entry.last_updated !== null) { _%>
-									<div class="c-entry-meta__group">
-										<dt>最終更新</dt>
-										<dd><time datetime="<%= entry.last_updated.format('YYYY-MM-DDTHH:mm:ssZ') %>"><%= entry.last_updated.format('YYYY年M月D日') %></time></dd>
-									</div>
-									<%_ } _%>
-								</dl>
+						<li>
+							<div class="c-entry-link">
+								<a href="/<%= entry.id %>">
+									<span class="c-entry-link__thumb">
+										<%_ if (entry.image_internal !== null) { _%>
+										<picture>
+											<source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=avif;w=180;h=180;quality=60, https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=avif;w=360;h=360;quality=30 2x" />
+											<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=webp;w=180;h=180;quality=60, https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=webp;w=360;h=360;quality=30 2x" />
+											<img src="https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=jpeg;w=180;h=180;quality=60" alt="" class="c-entry-link__image" />
+										</picture>
+										<%_ } else if (entry.image_external !== null) { _%>
+										<img src="<%= entry.image_external %>" alt="" class="c-entry-link__image" />
+										<%_ } else { _%>
+										<img src="/image/noimage.svg" alt="" width="180" height="120" class="c-entry-link__image" />
+										<%_ } _%>
+									</span>
+									<span class="c-entry-link__title"><%- entry.title %></span>
+								</a>
+								<div class="c-entry-link__date">
+									<dl class="c-entry-meta">
+										<div class="c-entry-meta__group">
+											<dt>投稿</dt>
+											<dd><time datetime="<%= entry.created.format('YYYY-MM-DDTHH:mm:ssZ') %>"><%= entry.created.format('YYYY年M月D日') %></time></dd>
+										</div>
+										<%_ if (entry.last_updated !== null) { _%>
+										<div class="c-entry-meta__group">
+											<dt>最終更新</dt>
+											<dd><time datetime="<%= entry.last_updated.format('YYYY-MM-DDTHH:mm:ssZ') %>"><%= entry.last_updated.format('YYYY年M月D日') %></time></dd>
+										</div>
+										<%_ } _%>
+									</dl>
+								</div>
 							</div>
 						</li>
 						<%_ } _%>

--- a/views/list.ejs
+++ b/views/list.ejs
@@ -45,36 +45,38 @@
 				<main class="l-content__main">
 					<ul class="p-title-list -list">
 						<%_ for (const entry of entries) { _%>
-						<li class="c-entry-link">
-							<a href="/<%= entry.id %>">
-								<span class="c-entry-link__thumb">
-									<%_ if (entry.image_internal !== null) { _%>
-									<picture>
-										<source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=avif;w=180;h=120;quality=60, https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=avif;w=360;h=240;quality=30 2x" />
-										<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=webp;w=180;h=120;quality=60, https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=webp;w=360;h=240;quality=30 2x" />
-										<img src="https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=jpeg;w=180;h=120;quality=60" alt="" class="c-entry-link__image" />
-									</picture>
-									<%_ } else if (entry.image_external !== null) { _%>
-									<img src="<%= entry.image_external %>" alt="" class="c-entry-link__image" />
-									<%_ } else { _%>
-									<img src="/image/noimage.svg" alt="" width="180" height="120" class="c-entry-link__image" />
-									<%_ } _%>
-								</span>
-								<span class="c-entry-link__title"><%- entry.title %></span>
-							</a>
-							<div class="c-entry-link__date">
-								<dl class="c-entry-meta">
-									<div class="c-entry-meta__group">
-										<dt>投稿</dt>
-										<dd><time datetime="<%= entry.created.format('YYYY-MM-DDTHH:mm:ssZ') %>"><%= entry.created.format('YYYY年M月D日') %></time></dd>
-									</div>
-									<%_ if (entry.last_updated !== null) { _%>
-									<div class="c-entry-meta__group">
-										<dt>最終更新</dt>
-										<dd><time datetime="<%= entry.last_updated.format('YYYY-MM-DDTHH:mm:ssZ') %>"><%= entry.last_updated.format('YYYY年M月D日') %></time></dd>
-									</div>
-									<%_ } _%>
-								</dl>
+						<li>
+							<div class="c-entry-link">
+								<a href="/<%= entry.id %>">
+									<span class="c-entry-link__thumb">
+										<%_ if (entry.image_internal !== null) { _%>
+										<picture>
+											<source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=avif;w=180;h=120;quality=60, https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=avif;w=360;h=240;quality=30 2x" />
+											<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=webp;w=180;h=120;quality=60, https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=webp;w=360;h=240;quality=30 2x" />
+											<img src="https://media.w0s.jp/thumbimage/blog/<%= entry.image_internal %>?type=jpeg;w=180;h=120;quality=60" alt="" class="c-entry-link__image" />
+										</picture>
+										<%_ } else if (entry.image_external !== null) { _%>
+										<img src="<%= entry.image_external %>" alt="" class="c-entry-link__image" />
+										<%_ } else { _%>
+										<img src="/image/noimage.svg" alt="" width="180" height="120" class="c-entry-link__image" />
+										<%_ } _%>
+									</span>
+									<span class="c-entry-link__title"><%- entry.title %></span>
+								</a>
+								<div class="c-entry-link__date">
+									<dl class="c-entry-meta">
+										<div class="c-entry-meta__group">
+											<dt>投稿</dt>
+											<dd><time datetime="<%= entry.created.format('YYYY-MM-DDTHH:mm:ssZ') %>"><%= entry.created.format('YYYY年M月D日') %></time></dd>
+										</div>
+										<%_ if (entry.last_updated !== null) { _%>
+										<div class="c-entry-meta__group">
+											<dt>最終更新</dt>
+											<dd><time datetime="<%= entry.last_updated.format('YYYY-MM-DDTHH:mm:ssZ') %>"><%= entry.last_updated.format('YYYY年M月D日') %></time></dd>
+										</div>
+										<%_ } _%>
+									</dl>
+								</div>
 							</div>
 						</li>
 						<%_ } _%>


### PR DESCRIPTION
原因は `.c-entry-link` に `margin-inline-start` が設定されるため。
そもそも `.p-title-list > li` にスタイルを設定している状況下で `<li class="c-entry-link">` としていることが干渉を呼んでいるので、 `<li><div class="c-entry-link">` に要素分離する。

![Screenshot 2023-03-07 at 11-38-32 富永日記帳](https://user-images.githubusercontent.com/4138486/223306031-633e21dc-8e0e-4695-a5d7-c2261feabc67.png)
