### PR TITLE
YouTube 埋め込み動画に開始秒が指定された場合、リンクが `?v=foo?t=XXX` となっていたバグを修正

### DIFF
--- a/node/src/util/MessageParser.ts
+++ b/node/src/util/MessageParser.ts
@@ -1236,16 +1236,13 @@ export default class MessageParser {
 		figcaptionElement.appendChild(captionTitleElement);
 
 		const aUrlSearchParams = new URLSearchParams();
+		aUrlSearchParams.set('v', id);
 		if (start !== undefined && start > 1) {
 			aUrlSearchParams.set('t', `${start}s`);
 		}
 
 		const aElement = this.#document.createElement('a');
-		if ([...aUrlSearchParams].length === 0 /* URLSearchParams のサイズ取得 https://github.com/whatwg/url/issues/163 */) {
-			aElement.href = `https://www.youtube.com/watch?v=${id}`;
-		} else {
-			aElement.href = `https://www.youtube.com/watch?v=${id}?${aUrlSearchParams.toString()}`;
-		}
+		aElement.href = `https://www.youtube.com/watch?${aUrlSearchParams.toString()}`;
 		aElement.textContent = caption;
 		captionTitleElement.appendChild(aElement);
 


### PR DESCRIPTION
- 誤: `?v=ID?t=100s`
- 正: `?v=ID&t=100s`
