### PR TITLE
サイト内検索に `<search>` 要素を使用する

### DIFF
--- a/views/_include/_header.ejs
+++ b/views/_include/_header.ejs
@@ -22,27 +22,29 @@
 				</a>
 			</div>
 
-			<form action="https://www.google.com/search" role="search" class="p-header-search">
-				<fieldset>
-					<legend class="p-header-search__legend">サイト内検索<span class="u-small">（Google 検索）</span></legend>
-					<div class="p-header-search__ctrl c-search">
-						<span class="c-search__hidden">
-							<input type="hidden" name="as_sitesearch" value="blog.w0s.jp" />
-						</span>
-						<span class="c-search__query">
-							<input type="search" name="q" required="" title="キーワード" />
-						</span>
-						<span class="c-search__submit">
-							<button>
-								<svg role="img" aria-labelledby="header-search-button">
-									<title id="header-search-button">検索</title>
-									<use href="/image/icon/search.svg#icon"></use>
-								</svg>
-							</button>
-						</span>
-					</div>
-				</fieldset>
-			</form>
+			<search role="search">
+				<form action="https://www.google.com/search" class="p-header-search">
+					<fieldset>
+						<legend class="p-header-search__legend">サイト内検索<span class="u-small">（Google 検索）</span></legend>
+						<div class="p-header-search__ctrl c-search">
+							<span class="c-search__hidden">
+								<input type="hidden" name="as_sitesearch" value="blog.w0s.jp" />
+							</span>
+							<span class="c-search__query">
+								<input type="search" name="q" required="" title="キーワード" />
+							</span>
+							<span class="c-search__submit">
+								<button>
+									<svg role="img" aria-labelledby="header-search-button">
+										<title id="header-search-button">検索</title>
+										<use href="/image/icon/search.svg#icon"></use>
+									</svg>
+								</button>
+							</span>
+						</div>
+					</fieldset>
+				</form>
+			</search>
 		</div>
 	</div>
 </header>


### PR DESCRIPTION
- 本日（3月24日）、HTML Standard に `<search>` 要素が追加された。👉[4.4.15 The `search` element](https://html.spec.whatwg.org/multipage/grouping-content.html#the-search-element)
- まだブラウザや支援技術の実装が追いついていないので、しばらくは `role="search"` を併用する
  - Firefox 111: ランドマーク扱いされない
  - Firefox 113.0a1 (Nightly): ランドマーク扱いされない
  - Chrome 111: ランドマーク扱いされない
  - Chrome 113.0.5671.0 (canaly): ランドマーク扱いされない
  - NVDA 2022.4jp: ランドマークとして読み上げられない