### PR TITLE
`<thead>` 内の空文字セルは `<td>` 要素にする

### DIFF
--- a/node/src/util/MessageParser.ts
+++ b/node/src/util/MessageParser.ts
@@ -998,10 +998,18 @@ export default class MessageParser {
 				sectionElement.appendChild(rowElement);
 
 				dataCols.forEach((data) => {
-					const cellElement = this.#document.createElement('th');
-					cellElement.setAttribute('scope', 'col');
-					cellElement.textContent = data.trim();
-					rowElement.appendChild(cellElement);
+					const text = data.trim();
+
+					if (text === '') {
+						const cellElement = this.#document.createElement('td');
+						cellElement.textContent = text;
+						rowElement.appendChild(cellElement);
+					} else {
+						const cellElement = this.#document.createElement('th');
+						cellElement.setAttribute('scope', 'col');
+						cellElement.textContent = text;
+						rowElement.appendChild(cellElement);
+					}
 				});
 			}
 


### PR DESCRIPTION
これまで本文の `<thead>` 内のセルはすべて `<th>` 要素としていたため、空セルの場合は `<th scope="col"></th>` が出力されていた。
これを `<td>` に変更する。
