### PR TITLE
`[text][link](URL)` のようにリンクの前方に `[` がある場合、全体がリンク文字になってしまうバグを修正

### DIFF
--- a/node/__tests__/@message/Inline.test.js
+++ b/node/__tests__/@message/Inline.test.js
@@ -52,6 +52,12 @@ describe('anchor', () => {
 		);
 	});
 
+	test('text in [', () => {
+		expect(inline.mark('[<s>text1</s>][<s>link1</s>](https://example.com/)[<s>text2</s>][<s>link2</s>](https://example.com/)')).toBe(
+			'[&lt;s&gt;text1&lt;/s&gt;]<a href="https://example.com/">&lt;s&gt;link1&lt;/s&gt;</a><b class="c-domain">(example.com)</b>[&lt;s&gt;text2&lt;/s&gt;]<a href="https://example.com/">&lt;s&gt;link2&lt;/s&gt;</a><b class="c-domain">(example.com)</b>'
+		);
+	});
+
 	test('URL &', () => {
 		expect(inline.mark('<s>text1</s>[<s>link1</s>](https://example.com/?foo=hoge&bar=piyo)<s>text2</s>')).toBe(
 			'&lt;s&gt;text1&lt;/s&gt;<a href="https://example.com/?foo=hoge&amp;bar=piyo">&lt;s&gt;link1&lt;/s&gt;</a><b class="c-domain">(example.com)</b>&lt;s&gt;text2&lt;/s&gt;'

--- a/node/src/util/@message/Inline.ts
+++ b/node/src/util/@message/Inline.ts
@@ -114,7 +114,7 @@ export default class Inline {
 	 * @returns {string} 変換後の HTML 文字列
 	 */
 	#markAnchor(input: string): string {
-		return input.replace(/\[(?<anchor>.+?)\]\((?<meta>[^(].*?)\)/g, (match, anchor_htmlescaped: string, meta_htmlescaped: string) => {
+		return input.replace(/\[(?<anchor>[^[]+?)\]\((?<meta>[^(].*?)\)/g, (match, anchor_htmlescaped: string, meta_htmlescaped: string) => {
 			const anchor = StringEscapeHtml.unescape(anchor_htmlescaped);
 			const meta = StringEscapeHtml.unescape(meta_htmlescaped);
 


### PR DESCRIPTION

実例として[Firefox 54 で appearance の接頭辞が外れるとか置換要素関連の変更とか](https://web.archive.org/web/20221007200319/https://blog.w0s.jp/509)の記事において

```
これまで、 `input[type="checkbox"], input[type="radio"] { -moz-appearance: none }` と指定しても、チェックボックス、ラジオボタンは置換要素にはならず、`::before`, `::after` 疑似要素のスタイルが適用されないといったことがありました((置換要素にこれら疑似要素が適用されない理由は、5年前の古い記事ですが[置換要素（imgなど）に対する :before, :after疑似要素の指定について](228)を参照ください。))。
```

が

```html
<p>これまで、 <code>input<a href="/228">type="checkbox"], input[type="radio"] { -moz-appearance: none }</a></code><a href="/228"> と指定しても、チェックボックス、ラジオボタンは置換要素にはならず、<code>::before</code>, <code>::after</code> 疑似要素のスタイルが適用されないといったことがありました<span class="c-annotate"></span></a><a href="#fn509-1" id="nt509-1" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[1]</a>。</p>
```

と変換されていた。
