### PR TITLE
同じ code 文字列が複数あった場合にページ内 ID が重複するバグを修正

### DIFF
--- a/node/__tests__/MessageParser.test.js
+++ b/node/__tests__/MessageParser.test.js
@@ -193,7 +193,7 @@ code2
 \`\`\`
 `)
 		)
-			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-7599e3e460f0cdcb6e7f57439f12a971" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-7599e3e460f0cdcb6e7f57439f12a971">code1
+			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-d58f8080245fe003007620661b93d2a9" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-d58f8080245fe003007620661b93d2a9">code1
 code2</code></pre></div>`);
 	});
 
@@ -206,7 +206,7 @@ code2
 \`\`\`
 `)
 		)
-			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-7599e3e460f0cdcb6e7f57439f12a971" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-7599e3e460f0cdcb6e7f57439f12a971" data-language="html">code1
+			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-d58f8080245fe003007620661b93d2a9" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-d58f8080245fe003007620661b93d2a9" data-language="html">code1
 code2</code></pre></div>`);
 	});
 
@@ -219,7 +219,7 @@ code2
 \`\`\`
 `)
 		)
-			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-7599e3e460f0cdcb6e7f57439f12a971" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-7599e3e460f0cdcb6e7f57439f12a971" data-language="css">code1
+			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-d58f8080245fe003007620661b93d2a9" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-d58f8080245fe003007620661b93d2a9" data-language="css">code1
 code2</code></pre></div>`);
 	});
 
@@ -232,7 +232,7 @@ code2
 \`\`\`
 `)
 		)
-			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-7599e3e460f0cdcb6e7f57439f12a971" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-7599e3e460f0cdcb6e7f57439f12a971" data-language="javascript">code1
+			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-d58f8080245fe003007620661b93d2a9" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-d58f8080245fe003007620661b93d2a9" data-language="javascript">code1
 code2</code></pre></div>`);
 	});
 
@@ -245,7 +245,7 @@ code2
 \`\`\`
 `)
 		)
-			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-7599e3e460f0cdcb6e7f57439f12a971" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-7599e3e460f0cdcb6e7f57439f12a971" data-language="typescript">code1
+			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-d58f8080245fe003007620661b93d2a9" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-d58f8080245fe003007620661b93d2a9" data-language="typescript">code1
 code2</code></pre></div>`);
 	});
 
@@ -258,7 +258,7 @@ code2
 \`\`\`
 `)
 		)
-			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-7599e3e460f0cdcb6e7f57439f12a971" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-7599e3e460f0cdcb6e7f57439f12a971" data-language="json">code1
+			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-d58f8080245fe003007620661b93d2a9" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-d58f8080245fe003007620661b93d2a9" data-language="json">code1
 code2</code></pre></div>`);
 	});
 
@@ -271,7 +271,7 @@ code2
 \`\`\`
 `)
 		)
-			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-7599e3e460f0cdcb6e7f57439f12a971" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-7599e3e460f0cdcb6e7f57439f12a971" data-language="xxx">code1
+			.toBe(`<div class="p-code"><div class="p-code__clipboard"><button type="button" is="w0s-clipboard" data-target-for="code-d58f8080245fe003007620661b93d2a9" class="p-code__clipboard-button"><img src="/image/entry/copy.svg" alt="コピー"></button></div><pre class="p-code__code"><code id="code-d58f8080245fe003007620661b93d2a9" data-language="xxx">code1
 code2</code></pre></div>`);
 	});
 

--- a/node/src/util/MessageParser.ts
+++ b/node/src/util/MessageParser.ts
@@ -206,13 +206,13 @@ export default class MessageParser {
 			message
 				.replaceAll(CRLF, LF)
 				.split(LF)
-				.map(async (line) => {
+				.map(async (line, index) => {
 					const firstCharactor = line.substring(0, 1); // 先頭文字
 
 					if (this.#code) {
 						if (line === '```') {
 							/* コードの終端になったらそれまでの蓄積分を append する */
-							this.#appendCode();
+							this.#appendCode(index);
 
 							this.#code = false;
 							this.#codeBody = undefined;
@@ -915,15 +915,17 @@ export default class MessageParser {
 
 	/**
 	 * code を挿入する
+	 *
+	 * @param {number} lastLineNo - コードの最後の行の行数
 	 */
-	#appendCode(): void {
+	#appendCode(lastLineNo?: number): void {
 		const code = this.#codeBody;
 		if (code === undefined) {
 			return;
 		}
 
 		const language = this.#codeLanguage;
-		const codeId = `code-${md5(code)}`; // コード ID
+		const codeId = `code-${md5(lastLineNo !== undefined ? `${lastLineNo}${code}` : code)}`; // コード ID（記事内でのユニークさを保つためにコード文字列と行数を組み合わせた文字列を元にする）
 
 		/* コードの挿入 */
 		const codeWrapperElement = this.#document.createElement('div');


### PR DESCRIPTION
従来はコード文字列（``` 内の文字列）を md5 した値を ID としていたが、記事内に同じコード文字列が複数あった場合に ID が重複する事例があったため、コード文字列に加えて行数を加えた文字列を md5 することでユニークさを担保するようにする。