### PR TITLE
`.markuplintrc` の見直し

### DIFF
--- a/.markuplintrc
+++ b/.markuplintrc
@@ -92,5 +92,22 @@
 				"class-naming": false
 			}
 		}
-	]
+	],
+	"overrides": {
+		"*.html": {
+			"rules": {
+				"label-has-control": true,
+				"require-accessible-name": true,
+				"required-h1": true
+			},
+			"nodeRules": [
+				{
+					"selector": "table",
+					"rules": {
+						"require-accessible-name": false
+					}
+				}
+			]
+		}
+	}
 }

--- a/.markuplintrc
+++ b/.markuplintrc
@@ -21,9 +21,7 @@
 			"u",
 			"br",
 			"wbr",
-			"embed",
-			"area",
-			"noscript"
+			"area"
 		],
 		"label-has-control": false,
 		"require-accessible-name": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
 				"@types/twitter-text": "^3.1.4",
 				"@types/w3c-xmlserializer": "^2.0.2",
 				"@w0s/eslint-config": "^1.1.0",
-				"@w0s/markuplint-config": "^2.3.0",
+				"@w0s/markuplint-config": "^2.4.0",
 				"@w0s/stylelint-config": "^1.1.0",
 				"@w0s/tsconfig": "^1.0.1",
 				"ajv-cli": "^5.0.0",
@@ -2535,9 +2535,9 @@
 			}
 		},
 		"node_modules/@w0s/markuplint-config": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@w0s/markuplint-config/-/markuplint-config-2.3.0.tgz",
-			"integrity": "sha512-W3qtw3zOurk2wzLZvRhy3eIMs0biBqTZNIOGVkFSCyqMgAwxqXtSYkpUonSqJgRf3f/jmftyqi2WxQRwzqBWJg==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@w0s/markuplint-config/-/markuplint-config-2.4.0.tgz",
+			"integrity": "sha512-4tyUwrFolBZtxROOidj5EMbi+n+sElrN+Qip2Qd6Y6A9TErPL/ABQfp0tRTid0uLHECTOBnqFfM1PFxkjWRZmg==",
 			"dev": true,
 			"peerDependencies": {
 				"markuplint": "^3.7.0"
@@ -15799,9 +15799,9 @@
 			}
 		},
 		"@w0s/markuplint-config": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/@w0s/markuplint-config/-/markuplint-config-2.3.0.tgz",
-			"integrity": "sha512-W3qtw3zOurk2wzLZvRhy3eIMs0biBqTZNIOGVkFSCyqMgAwxqXtSYkpUonSqJgRf3f/jmftyqi2WxQRwzqBWJg==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/@w0s/markuplint-config/-/markuplint-config-2.4.0.tgz",
+			"integrity": "sha512-4tyUwrFolBZtxROOidj5EMbi+n+sElrN+Qip2Qd6Y6A9TErPL/ABQfp0tRTid0uLHECTOBnqFfM1PFxkjWRZmg==",
 			"dev": true,
 			"requires": {}
 		},

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
 		"@types/twitter-text": "^3.1.4",
 		"@types/w3c-xmlserializer": "^2.0.2",
 		"@w0s/eslint-config": "^1.1.0",
-		"@w0s/markuplint-config": "^2.3.0",
+		"@w0s/markuplint-config": "^2.4.0",
 		"@w0s/stylelint-config": "^1.1.0",
 		"@w0s/tsconfig": "^1.0.1",
 		"ajv-cli": "^5.0.0",


### PR DESCRIPTION
- `embed`, `noscript` 要素の禁止設定を `@w0s/markuplint-config` に移行
- 一部ルールの無効化を `overrides` を使用して HTML ファイルには適用しない（EJS ファイルのみ除外させる）ように