### PR TITLE
構造化データを Microdata から JSON-LD に変更

### DIFF
--- a/views/_include/_header.ejs
+++ b/views/_include/_header.ejs
@@ -2,16 +2,16 @@
 	<div class="l-header__main">
 		<div class="l-header__site">
 			<div class="p-header-site">
-				<%_ if (heading) { _%><%_ if (page.path === '/') { _%>
-				<h1 class="p-header-site__name" itemprop="name"><a aria-current="page">富永日記帳</a></h1>
-				<%_ } else { _%>
-				<h1 class="p-header-site__name" itemprop="name"><a href="/">富永日記帳</a></h1>
-				<%_ } _%>
-				<p class="p-header-site__summary" itemprop="description">ウェブ技術や東急電車、久米田康治作品の話を中心としたブログ</p>
+				<%_ if (heading) { _%>
+					<%_ if (page.path === '/') { _%>
+					<h1 class="p-header-site__name"><a aria-current="page">富永日記帳</a></h1>
+					<%_ } else { _%>
+					<h1 class="p-header-site__name"><a href="/">富永日記帳</a></h1>
+					<%_ } _%>
 				<%_ } else { _%>
 				<div class="p-header-site__name"><a href="/">富永日記帳</a></div>
-				<p class="p-header-site__summary">ウェブ技術や東急電車、久米田康治作品の話を中心としたブログ</p>
 				<%_ } _%>
+				<p class="p-header-site__summary">ウェブ技術や東急電車、久米田康治作品の話を中心としたブログ</p>
 			</div>
 		</div>
 		<div class="l-header__nav">

--- a/views/category.ejs
+++ b/views/category.ejs
@@ -16,14 +16,14 @@
 		<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
 		<script src="/script/analytics.js" defer=""></script>
 	</head>
-	<body itemscope="" itemtype="http://schema.org/Blog">
+	<body>
 		<div class="l-page">
 			<%- include('./_include/_header', { heading: false } ) -%>
 
 			<div id="content" class="l-content">
 				<div class="l-content__header">
 					<div class="p-title">
-						<h1 itemprop="name">「<%= page.query.category_name %>」の記事（<%= count %>件）</h1>
+						<h1>「<%= page.query.category_name %>」の記事（<%= count %>件）</h1>
 					</div>
 				</div>
 				<main class="l-content__main">

--- a/views/entry.ejs
+++ b/views/entry.ejs
@@ -38,34 +38,38 @@
 		<%_ } _%>
 		<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
 		<script src="/script/analytics.js" defer=""></script>
+
+		<script type="application/ld+json">
+			<%- jsonLd %>
+		</script>
 	</head>
-	<body itemscope="" itemtype="http://schema.org/Blog">
+	<body>
 		<div class="l-page">
 			<%- include('./_include/_header', { heading: false } ) -%>
 
 			<div id="content" class="l-content">
 				<div class="l-content__main">
-					<article class="p-entry" itemscope="" itemtype="http://schema.org/BlogPosting">
+					<article class="p-entry">
 						<header class="p-entry__header">
 							<div class="p-entry-header-title">
-								<h1 itemprop="name"><%- title_marked %></h1>
+								<h1><%- title_marked %></h1>
 							</div>
 
 							<dl class="p-entry-header-date c-entry-meta">
 								<div class="c-entry-meta__group">
 									<dt>投稿</dt>
-									<dd><time datetime="<%= created.format('YYYY-MM-DDTHH:mm:ssZ') %>" itemprop="datePublished"><%= created.format('YYYY年M月D日') %></time></dd>
+									<dd><time datetime="<%= created.format('YYYY-MM-DDTHH:mm:ssZ') %>"><%= created.format('YYYY年M月D日') %></time></dd>
 								</div>
 								<%_ if (lastUpdated !== null) { _%>
 								<div class="c-entry-meta__group">
 									<dt>最終更新</dt>
-									<dd><time datetime="<%= lastUpdated.format('YYYY-MM-DDTHH:mm:ssZ') %>" itemprop="dateModified"><%= lastUpdated.format('YYYY年M月D日') %></time></dd>
+									<dd><time datetime="<%= lastUpdated.format('YYYY-MM-DDTHH:mm:ssZ') %>"><%= lastUpdated.format('YYYY年M月D日') %></time></dd>
 								</div>
 								<%_ } _%>
 							</dl>
 						</header>
 
-						<main class="p-entry__body" itemprop="articleBody"><%- message %></main>
+						<main class="p-entry__body"><%- message %></main>
 
 						<footer class="p-entry__footer">
 							<%_ if (categoryNames.length >= 1) { _%>

--- a/views/list.ejs
+++ b/views/list.ejs
@@ -23,7 +23,7 @@
 		<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
 		<script src="/script/analytics.js" defer=""></script>
 	</head>
-	<body itemscope="" itemtype="http://schema.org/Blog">
+	<body>
 		<div class="l-page">
 			<%- include('./_include/_header', { heading: true } ) -%>
 


### PR DESCRIPTION
（今さらではあるが）[Google は  JSON-LD を推奨](https://developers.google.com/search/docs/appearance/structured-data/intro-structured-data?hl=ja#supported-formats)している。

- 記事ページの構造化データを Microdata から JSON-LD に変更
  - `name` は `headline` に変更する
  - `articleBody` を JSON-LD に持つことはファイルサイズの観点から望ましくないので廃止する
- 記事ページ以外の構造化データを廃止