### PR TITLE
`<main>` 要素の位置を `<article>` 要素の外に変更

### DIFF
--- a/views/entry.ejs
+++ b/views/entry.ejs
@@ -50,7 +50,7 @@
 			<%- include('./_include/header', { heading: false } ) -%>
 
 			<div id="content" class="l-content">
-				<div class="l-content__main">
+				<main class="l-content__main">
 					<article class="p-entry">
 						<header class="p-entry__header">
 							<div class="p-entry-header-title">
@@ -71,7 +71,7 @@
 							</dl>
 						</header>
 
-						<main class="p-entry__body"><%- message %></main>
+						<div class="p-entry__body"><%- message %></div>
 
 						<footer class="p-entry__footer">
 							<%_ if (categoryNames.length >= 1) { _%>
@@ -141,7 +141,7 @@
 							<%_ } _%>
 						</footer>
 					</article>
-				</div>
+				</main>
 
 				<%_ if (categoryFileNames === 'railway') { _%>
 				<div class="l-content__footer">


### PR DESCRIPTION
[4.4.14 main要素](https://momdo.github.io/html/grouping-content.html#hierarchically-correct-main-element)では以下のような記述がある。

> 階層的に正しいmain要素は、祖先要素がhtml、body、div、アクセシブルな名前のないform、および自律カスタム要素に限定されるものである。各main要素は、階層的に正しいmain要素でなければならない。

記事ページのみ、`<main>` 要素の位置がなぜか `.l-content__main` でなく `.p-entry__body` になっていたので統一する。