### PR TITLE
`<script>` 要素による外部ファイル読み込みを `defer` に統一

### DIFF
--- a/views/category.ejs
+++ b/views/category.ejs
@@ -9,9 +9,9 @@
 		<link rel="alternate stylesheet" href="/style/layout_reader.css" title="リーダー表示" />
 		<link rel="stylesheet" href="/style/layout_reader.css" media="print" />
 
-		<script src="/script/trusted-types.js"></script>
+		<script src="/script/trusted-types.js" defer=""></script>
 		<script src="/script/blog.mjs" type="module"></script>
-		<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
+		<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
 		<script src="/script/analytics.js" defer=""></script>
 
 		<title>富永日記帳: 「<%= requestQuery.category_name %>」の記事（<%= count %>件）</title>

--- a/views/entry.ejs
+++ b/views/entry.ejs
@@ -9,12 +9,12 @@
 		<link rel="alternate stylesheet" href="/style/layout_reader.css" title="リーダー表示" />
 		<link rel="stylesheet" href="/style/layout_reader.css" media="print" />
 
-		<script src="/script/trusted-types.js"></script>
+		<script src="/script/trusted-types.js" defer=""></script>
 		<script src="/script/blog.mjs" type="module"></script>
 		<%_ if (tweet) { _%>
-		<script src="https://platform.twitter.com/widgets.js" async=""></script>
+		<script src="https://platform.twitter.com/widgets.js" defer=""></script>
 		<%_ } _%>
-		<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
+		<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
 		<script src="/script/analytics.js" defer=""></script>
 
 		<title><%= structuredData.title %></title>

--- a/views/list.ejs
+++ b/views/list.ejs
@@ -16,9 +16,9 @@
 		<link rel="alternate stylesheet" href="/style/layout_reader.css" title="リーダー表示" />
 		<link rel="stylesheet" href="/style/layout_reader.css" media="print" />
 
-		<script src="/script/trusted-types.js"></script>
+		<script src="/script/trusted-types.js" defer=""></script>
 		<script src="/script/blog.mjs" type="module"></script>
-		<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
+		<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
 		<script src="/script/analytics.js" defer=""></script>
 
 		<title>富永日記帳<%_ if (requestQuery.page !== 1) { _%>: タイトル一覧（<%= requestQuery.page %>ページ目）<%_ } _%></title>


### PR DESCRIPTION
`defer` 属性や `async` 属性のファイル読み込み順序はブラウザによって異なるが、すべて `defer` に統一した場合は Firefox, Chrome ともソース順に読み込まれる。