### PR TITLE
'analytics.ts' が二重登録されていたバグ修正

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -8,7 +8,7 @@ const inputDir = `${baseDir}/_src`;
 const outputDir = `${baseDir}`;
 
 const moduleFiles = ['blog.ts', 'error.ts', 'admin.ts'];
-const jsFiles = ['trusted-types.ts', 'analytics.ts'];
+const jsFiles = ['trusted-types.ts'];
 const legacyFiles = ['analytics.ts'];
 
 const pluginCommonjs = commonjs();


### PR DESCRIPTION
#259 の改修において 'analytics.ts' が `jsFiles` と `legacyFiles` の両方に登録されていたバグを修正