### PR TITLE
'matomo.js'  の読み込みタグを `async` に戻す

### DIFF
--- a/views/category.ejs
+++ b/views/category.ejs
@@ -11,7 +11,7 @@
 
 		<script src="/script/trusted-types.js" defer=""></script>
 		<script src="/script/blog.mjs" type="module"></script>
-		<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
+		<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
 		<script src="/script/analytics.js" defer=""></script>
 
 		<title>富永日記帳: 「<%= requestQuery.category_name %>」の記事（<%= count %>件）</title>

--- a/views/entry.ejs
+++ b/views/entry.ejs
@@ -14,7 +14,7 @@
 		<%_ if (tweet) { _%>
 		<script src="https://platform.twitter.com/widgets.js" defer=""></script>
 		<%_ } _%>
-		<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
+		<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
 		<script src="/script/analytics.js" defer=""></script>
 
 		<title><%= structuredData.title %></title>

--- a/views/list.ejs
+++ b/views/list.ejs
@@ -18,7 +18,7 @@
 
 		<script src="/script/trusted-types.js" defer=""></script>
 		<script src="/script/blog.mjs" type="module"></script>
-		<script src="https://analytics.w0s.jp/matomo/matomo.js" defer=""></script>
+		<script src="https://analytics.w0s.jp/matomo/matomo.js" async=""></script>
 		<script src="/script/analytics.js" defer=""></script>
 
 		<title>富永日記帳<%_ if (requestQuery.page !== 1) { _%>: タイトル一覧（<%= requestQuery.page %>ページ目）<%_ } _%></title>


### PR DESCRIPTION
#257 で `<script>` 要素による外部ファイル読み込みを `defer` に統一したが、アクセス解析用途の 'matomo.js' は `async` でしか動かないため元に戻す