### PR TITLE
highlight.js 11.8 にアップデート

### DIFF
--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -4,7 +4,7 @@
 	"exclude": ["__tests__/*.test.js"],
 	"compilerOptions": {
 		/* Modules */
-		"moduleResolution": "Node", // "Node16" だと `node_modules/highlight.js/es/core.d.ts:1:18 - error TS7016` でコンパイル不能
+		"moduleResolution": "Node", // "Node16" だと `error TS2307: Cannot find module 'twitter-api-v2/dist/v2/client.v2.write' or its corresponding type declarations.` でコンパイル不能
 
 		/* Emit */
 		"outDir": "dist",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
 				"filenamify": "^5.1.1",
 				"github-slugger": "^2.0.0",
 				"globby": "^13.1.3",
-				"highlight.js": "^11.6.0",
+				"highlight.js": "^11.8.0",
 				"htpasswd-js": "^1.0.2",
 				"jsdom": "^20.0.1",
 				"kill-port": "^2.0.1",
@@ -6479,9 +6479,9 @@
 			}
 		},
 		"node_modules/highlight.js": {
-			"version": "11.7.0",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.7.0.tgz",
-			"integrity": "sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ==",
+			"version": "11.8.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
+			"integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==",
 			"engines": {
 				"node": ">=12.0.0"
 			}
@@ -18788,9 +18788,9 @@
 			"integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
 		},
 		"highlight.js": {
-			"version": "11.7.0",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.7.0.tgz",
-			"integrity": "sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ=="
+			"version": "11.8.0",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
+			"integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg=="
 		},
 		"homedir-polyfill": {
 			"version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 		"filenamify": "^5.1.1",
 		"github-slugger": "^2.0.0",
 		"globby": "^13.1.3",
-		"highlight.js": "^11.6.0",
+		"highlight.js": "^11.8.0",
 		"htpasswd-js": "^1.0.2",
 		"jsdom": "^20.0.1",
 		"kill-port": "^2.0.1",


### PR DESCRIPTION
TypeScript 設定の [`moduleResolution`](https://www.typescriptlang.org/tsconfig#moduleResolution) 関連のバグが修正されたが、引き続き `twitter-api-v2` でエラーが発生するのでまだ設定変更はできない。
