### PR TITLE
`cite`, `dfn`, `em` を一律で太字にしていたが、日本語以外はデフォルトの斜体のままにする

### DIFF
--- a/packages/frontend/public/style/_src/foundation/_elements.css
+++ b/packages/frontend/public/style/_src/foundation/_elements.css
@@ -50,17 +50,12 @@ w0s-tooltip:focus {
 	color: var(--color-black);
 }
 
-h1,
-h2,
-h3,
-h4,
 em,
-strong,
 cite,
-dfn,
-b,
-th {
-	font-weight: var(--font-weight-bold);
+dfn {
+	&:lang(ja) {
+		font-weight: var(--font-weight-bold);
+	}
 }
 
 pre {

--- a/packages/frontend/public/style/_src/foundation/_reset.css
+++ b/packages/frontend/public/style/_src/foundation/_reset.css
@@ -56,7 +56,9 @@ th {
 em,
 cite,
 dfn {
-	font-style: normal;
+	&:lang(ja) {
+		font-style: normal;
+	}
 }
 
 mark {


### PR DESCRIPTION
とくに `blockquote` 引用の中で英文の強調をする場合に太字になるのが気になる。