### PR TITLE
インライン変換処理で外枠のタグが `<p>` 以外の時のバグを修正

### DIFF
--- a/packages/backend/node/src/markdown/Inline.ts
+++ b/packages/backend/node/src/markdown/Inline.ts
@@ -16,7 +16,7 @@ interface MarkOption {
  * 記事メッセージのインライン処理
  */
 export default class MarkdownInline {
-	/*  */
+	/* unified Processor */
 	readonly #processor: Processor;
 
 	/* 注釈 */
@@ -71,11 +71,12 @@ export default class MarkdownInline {
 
 		const htmlBlock = this.#processor.processSync(inputEscaped).value.toString();
 
-		let html = htmlBlock.replace('<p>', '').replace('</p>', ''); // 外枠の <p></p> を削除
+		let html = htmlBlock.replace(/^<[a-z][a-z0-9-]*>/, '').replace(/<\/[a-z][a-z0-9-]*>$/, ''); // 外枠のタグを削除
 
 		if (options.footnote) {
 			html = this.#footnote(html);
 		}
+
 		return html;
 	}
 


### PR DESCRIPTION
#271 のバグ

```markdown
> # text
```

のような場合、

1. block 処理で `> ` を引用と判断
1. 残る `# text` を remark に掛ける
1. **引用の中身が `<h1>` と判断されてしまう**

現在は `<p>` が来ること前提の処理を行っていたため、任意のタグを削除するように変更する。
なお、Markdown 自体も

```markdown
> \# text
```

のようにエスケープ処理を行う必要がある。（将来的になんとかしたい）