### PR TITLE
rehype-stringify の出力結果で HTML のエスケープに名前付き文字参照を使うようにする

### DIFF
--- a/packages/backend/node/src/markdown/Inline.ts
+++ b/packages/backend/node/src/markdown/Inline.ts
@@ -37,6 +37,9 @@ export default class MarkdownInline {
 			},
 		}); // mdast → hast
 		processor.use(rehypeStringify, {
+			entities: {
+				useNamedReferences: true,
+			},
 			closeSelfClosing: true,
 			tightSelfClosing: true,
 		}); // hast → HTML


### PR DESCRIPTION
#271 の追加処理