### PR TITLE
記事タイトルの Markdown 処理を Ramark から独自処理に変更

### DIFF
--- a/packages/backend/node/__tests__/MarkdownTitle.test.js
+++ b/packages/backend/node/__tests__/MarkdownTitle.test.js
@@ -1,0 +1,22 @@
+import { describe, expect, test } from '@jest/globals';
+import MarkdownTitle from '../dist/markdown/Title.js';
+
+describe('code', () => {
+	test('single', () => {
+		expect(new MarkdownTitle('text1`code1`text2').mark()).toBe('text1<code>code1</code>text2');
+	});
+
+	test('multiple', () => {
+		expect(new MarkdownTitle('text1`code1``code2`').mark()).toBe(
+			'text1<code>code1</code><code>code2</code>'
+		);
+	});
+
+	test('open only', () => {
+		expect(new MarkdownTitle('text1`text2').mark()).toBe('text1`text2');
+	});
+
+	test('HTML escape', () => {
+		expect(new MarkdownTitle('<s>text1</s>`<s>code1</s>`<s>text2</s>').mark()).toBe('&lt;s&gt;text1&lt;/s&gt;<code>&lt;s&gt;code1&lt;/s&gt;</code>&lt;s&gt;text2&lt;/s&gt;');
+	});
+});

--- a/packages/backend/node/src/controller/CategoryController.ts
+++ b/packages/backend/node/src/controller/CategoryController.ts
@@ -7,10 +7,10 @@ import { Request, Response } from 'express';
 import BlogCategoryDao from '../dao/BlogCategoryDao.js';
 import Controller from '../Controller.js';
 import ControllerInterface from '../ControllerInterface.js';
+import MarkdownTitle from '../markdown/Title.js';
 import HttpResponse from '../util/HttpResponse.js';
 import RequestUtil from '../util/RequestUtil.js';
 import Sidebar from '../util/Sidebar.js';
-import MarkdownInline from '../markdown/Inline.js';
 import { NoName as Configure } from '../../../configure/type/category.js';
 import { NoName as ConfigureCommon } from '../../../configure/type/common.js';
 
@@ -67,9 +67,7 @@ export default class CategoryController extends Controller implements Controller
 			return;
 		}
 
-		const markdownInline = new MarkdownInline();
-
-		const sidebar = new Sidebar(dao, markdownInline);
+		const sidebar = new Sidebar(dao);
 
 		const [entryCountOfCategoryList, newlyEntries] = await Promise.all([
 			sidebar.getEntryCountOfCategory(),
@@ -107,7 +105,7 @@ export default class CategoryController extends Controller implements Controller
 
 			entries.push({
 				id: entryDto.id,
-				title: markdownInline.mark(entryDto.title),
+				title: new MarkdownTitle(entryDto.title).mark(),
 				image_internal: entryDto.image_internal,
 				image_external: imageExternal,
 				created: dayjs(entryDto.created),

--- a/packages/backend/node/src/controller/EntryController.ts
+++ b/packages/backend/node/src/controller/EntryController.ts
@@ -6,7 +6,7 @@ import BlogEntryDao from '../dao/BlogEntryDao.js';
 import Controller from '../Controller.js';
 import ControllerInterface from '../ControllerInterface.js';
 import Markdown from '../markdown/Markdown.js';
-import MarkdownInline from '../markdown/Inline.js';
+import MarkdownTitle from '../markdown/Title.js';
 import HttpResponse from '../util/HttpResponse.js';
 import RequestUtil from '../util/RequestUtil.js';
 import Sidebar from '../util/Sidebar.js';
@@ -69,9 +69,7 @@ export default class EntryController extends Controller implements ControllerInt
 			dbh: await dao.getDbh(),
 		});
 
-		const markdownInline = new MarkdownInline();
-
-		const sidebar = new Sidebar(dao, markdownInline);
+		const sidebar = new Sidebar(dao);
 
 		const [message, categoriesDto, relationDataListDto, entryCountOfCategoryList, newlyEntries] = await Promise.all([
 			markdown.toHtml(entryDto.message),
@@ -92,7 +90,7 @@ export default class EntryController extends Controller implements ControllerInt
 		for (const relationData of relationDataListDto) {
 			relations.push({
 				id: relationData.id,
-				title: markdownInline.mark(relationData.title),
+				title: new MarkdownTitle(relationData.title).mark(),
 				image_internal: relationData.image_internal,
 				image_external: relationData.image_external,
 				created: dayjs(relationData.created),
@@ -101,7 +99,7 @@ export default class EntryController extends Controller implements ControllerInt
 
 		const structuredData = {
 			title: entryDto.title,
-			title_marked: markdownInline.mark(entryDto.title),
+			title_marked: new MarkdownTitle(entryDto.title).mark(),
 			datePublished: dayjs(entryDto.created_at),
 			dateModified: entryDto.updated_at !== null ? dayjs(entryDto.updated_at) : undefined,
 			description: entryDto.description ?? undefined,

--- a/packages/backend/node/src/controller/ListController.ts
+++ b/packages/backend/node/src/controller/ListController.ts
@@ -9,7 +9,7 @@ import ControllerInterface from '../ControllerInterface.js';
 import HttpResponse from '../util/HttpResponse.js';
 import RequestUtil from '../util/RequestUtil.js';
 import Sidebar from '../util/Sidebar.js';
-import MarkdownInline from '../markdown/Inline.js';
+import MarkdownTitle from '../markdown/Title.js';
 import { NoName as Configure } from '../../../configure/type/list.js';
 import { NoName as ConfigureCommon } from '../../../configure/type/common.js';
 
@@ -65,9 +65,7 @@ export default class ListController extends Controller implements ControllerInte
 			return;
 		}
 
-		const markdownInline = new MarkdownInline();
-
-		const sidebar = new Sidebar(dao, markdownInline);
+		const sidebar = new Sidebar(dao);
 
 		const [entryCount, entryCountOfCategoryList, newlyEntries] = await Promise.all([
 			dao.getEntryCount(),
@@ -106,7 +104,7 @@ export default class ListController extends Controller implements ControllerInte
 
 			entries.push({
 				id: entryDto.id,
-				title: markdownInline.mark(entryDto.title),
+				title: new MarkdownTitle(entryDto.title).mark(),
 				image_internal: entryDto.image_internal,
 				image_external: imageExternal,
 				created: dayjs(entryDto.created),

--- a/packages/backend/node/src/controller/PostController.ts
+++ b/packages/backend/node/src/controller/PostController.ts
@@ -13,7 +13,7 @@ import Compress from '../util/Compress.js';
 import Controller from '../Controller.js';
 import ControllerInterface from '../ControllerInterface.js';
 import Markdown from '../markdown/Markdown.js';
-import MarkdownInline from '../markdown/Inline.js';
+import MarkdownTitle from '../markdown/Title.js';
 import HttpBasicAuth, { Credentials as HttpBasicAuthCredentials } from '../util/HttpBasicAuth.js';
 import HttpResponse from '../util/HttpResponse.js';
 import PostValidator from '../validator/PostValidator.js';
@@ -398,7 +398,7 @@ export default class PostController extends Controller implements ControllerInte
 					const newlyJson = JSON.stringify(
 						datas.map((data) => ({
 							id: data.id,
-							title: new MarkdownInline().mark(data.title),
+							title: new MarkdownTitle(data.title).mark(),
 						}))
 					);
 

--- a/packages/backend/node/src/markdown/Title.ts
+++ b/packages/backend/node/src/markdown/Title.ts
@@ -1,0 +1,68 @@
+import StringEscapeHtml from '@saekitominaga/string-escape-html';
+
+/**
+ * 記事タイトルの処理
+ */
+export default class MarkdownTitle {
+	#value: string;
+
+	/**
+	 * @param {string} input - 処理対象のテキスト
+	 */
+	constructor(input: string) {
+		this.#value = StringEscapeHtml.escape(input);
+	}
+
+	/**
+	 * 変換実行
+	 *
+	 * @returns {string} - 変換後の HTML 文字列
+	 */
+	mark(): string {
+		this.#code();
+
+		return this.#value;
+	}
+
+	/**
+	 * <code>
+	 */
+	#code(): void {
+		const CODE_OPEN = '`';
+		const CODE_CLOSE = '`';
+
+		/**
+		 * 変換実行
+		 *
+		 * @param {number} fromIndex - 検索を始める位置
+		 *
+		 * @returns {number} 未処理文字列の開始位置（これ以上処理が不要なときは undefined）
+		 */
+		const convert = (fromIndex = 0): number | undefined => {
+			const codeOpenIndex = this.#value.indexOf(CODE_OPEN, fromIndex);
+			if (codeOpenIndex === -1) {
+				return undefined;
+			}
+			const codeCloseIndex = this.#value.indexOf(CODE_CLOSE, codeOpenIndex + CODE_OPEN.length);
+			if (codeCloseIndex === -1) {
+				return undefined;
+			}
+
+			const beforeCodeValue = this.#value.substring(0, codeOpenIndex);
+			const codeValue = this.#value.substring(codeOpenIndex + CODE_OPEN.length, codeCloseIndex);
+			const afterCodeValue = this.#value.substring(codeCloseIndex + CODE_CLOSE.length);
+
+			const converted = `${beforeCodeValue}<code>${codeValue}</code>`;
+			const unconvertedIndex = converted.length;
+
+			this.#value = `${converted}${afterCodeValue}`;
+
+			return unconvertedIndex;
+		};
+
+		let unconvertedIndex = convert();
+		while (unconvertedIndex !== undefined) {
+			unconvertedIndex = convert(unconvertedIndex);
+		}
+	}
+}

--- a/packages/backend/node/src/util/Sidebar.ts
+++ b/packages/backend/node/src/util/Sidebar.ts
@@ -1,5 +1,5 @@
 import BlogDao from '../dao/BlogDao.js';
-import MarkdownInline from '../markdown/Inline.js';
+import MarkdownTitle from '../markdown/Title.js';
 
 interface NewlyEntry {
 	id: number;
@@ -15,18 +15,13 @@ interface EntryCountOfCategory {
  * サイドバー
  */
 export default class Sidebar {
-	#markdownInline: MarkdownInline;
-
 	#dao: BlogDao;
 
 	/**
 	 * @param {BlogDao} dao - 日記共通 Dao
-	 * @param {MarkdownInline} markdownInline - 記事メッセージのインライン処理
 	 */
-	constructor(dao: BlogDao, markdownInline: MarkdownInline) {
+	constructor(dao: BlogDao) {
 		this.#dao = dao;
-
-		this.#markdownInline = markdownInline;
 	}
 
 	/**
@@ -64,7 +59,7 @@ export default class Sidebar {
 		for (const entryDto of entriesDto) {
 			entries.push({
 				id: entryDto.id,
-				title: this.#markdownInline.mark(entryDto.title),
+				title: new MarkdownTitle(entryDto.title).mark(),
 			});
 		}
 


### PR DESCRIPTION
#271 で Remark を導入したが、記事タイトルは `<code>` 変換のみしかしないため、以下のようなケースで不具合が生じる。

| 記事タイトル | 想定 | 実際 |
|-|-|-|
| ``# text`code`*text*`` | `# text<code>code</code>*text*` | `<h1>text<code>code</code><em>text</em></h1>` |

`<em>` などインラインの変換はともかく、先頭に `#` や `>` があるのは今後充分想定されるため、ここは独自実装とする。