### PR TITLE
脚注のフォーマットを Markdown Extended Syntax に合わせる

### DIFF
--- a/packages/backend/node/__tests__/Markdown.test.js
+++ b/packages/backend/node/__tests__/Markdown.test.js
@@ -434,18 +434,16 @@ $text
 	});
 });
 
-describe('inline', () => {
-	test('empty', async () => {
-		expect(await new Markdown({ config: config, dbh: dbh }).toHtml('- ')).toBe('<ul class="p-list"><li></li></ul>');
+describe('footnote', () => {
+	test('normal', async () => {
+		expect(await new Markdown(config).toHtml('text1[^f1]text2\n\n[^f1]: footnote1')).toBe(
+			'<p>text1<span class="c-annotate"><a href="#footnote-f1" id="footnote-ref-f1" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[1]</a></span>text2</p><ul class="p-footnotes"><li><span class="p-footnotes__no"><a href="#footnote-ref-f1">[1]</a></span><span class="p-footnotes__text" id="footnote-f1">footnote1</span></li></ul>'
+		);
 	});
 
-	test('all', async () => {
-		expect(
-			await new Markdown(config).toHtml(
-				'<s>text</s>[link<s>link</s>](https://example.com/)*em<s>em</s>*`code<s>code</s>`{{quote<s>quote</s>}}((footnote<s>footnote</s>))<s>text</s>'
-			)
-		).toBe(
-			'<p>&lt;s&gt;text&lt;/s&gt;<a href="https://example.com/">link&lt;s&gt;link&lt;/s&gt;</a><b class="c-domain">(example.com)</b><em>em&lt;s&gt;em&lt;/s&gt;</em><code>code&lt;s&gt;code&lt;/s&gt;</code><q>quote&lt;s&gt;quote&lt;/s&gt;</q><span class="c-annotate"><a href="#fn1" id="nt1" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[1]</a></span>&lt;s&gt;text&lt;/s&gt;</p><ul class="p-footnotes"><li><span class="p-footnotes__no"><a href="#nt1">[1]</a></span><span class="p-footnotes__text" id="fn1">footnote&lt;s&gt;footnote&lt;/s&gt;</span></li></ul>'
+	test('no definition', async () => {
+		expect(await new Markdown(config).toHtml('text1[^f1]text2')).toBe(
+			'<p>text1<span class="c-annotate"><a href="#footnote-f1" id="footnote-ref-f1" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[1]</a></span>text2</p><ul class="p-footnotes"><li><span class="p-footnotes__no"><a href="#footnote-ref-f1">[1]</a></span><span class="p-footnotes__text" id="footnote-f1"></span></li></ul>'
 		);
 	});
 });

--- a/packages/backend/node/__tests__/MarkdownInline.test.js
+++ b/packages/backend/node/__tests__/MarkdownInline.test.js
@@ -1,203 +1,146 @@
 import { describe, expect, test } from '@jest/globals';
 import MarkdownInline from '../dist/markdown/Inline.js';
 
+const inline = new MarkdownInline();
+
 test('empty', () => {
-	const inline = new MarkdownInline();
 	expect(inline.mark('')).toBe('');
 });
 
 describe('code', () => {
-	const inline = new MarkdownInline();
-
 	test('single', () => {
+		expect(inline.mark('text1`code1`text2')).toBe('text1<code>code1</code>text2');
+	});
+
+	test('HTML escape', () => {
 		expect(inline.mark('<s>text1</s>`<s>code1</s>`<s>text2</s>')).toBe('&lt;s>text1&lt;/s><code>&lt;s>code1&lt;/s></code>&lt;s>text2&lt;/s>');
-	});
-
-	test('multiple', () => {
-		expect(inline.mark('<s>text1</s>`<s>code1</s>`<s>text2</s>`<s>code2</s>`')).toBe(
-			'&lt;s>text1&lt;/s><code>&lt;s>code1&lt;/s></code>&lt;s>text2&lt;/s><code>&lt;s>code2&lt;/s></code>'
-		);
-	});
-
-	test('escape', () => {
-		expect(inline.mark('<s>text1</s>\\`<s>code1</s>\\`<s>text2</s>')).toBe('&lt;s>text1&lt;/s>`&lt;s>code1&lt;/s>`&lt;s>text2&lt;/s>');
 	});
 });
 
 describe('anchor', () => {
-	const inline = new MarkdownInline();
-
-	test('single', () => {
-		expect(inline.mark('<s>text1</s>[<s>link1</s>](https://example.com/)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><a href="https://example.com/">&lt;s>link1&lt;/s></a><b class="c-domain">(example.com)</b>&lt;s>text2&lt;/s>'
-		);
-	});
-
-	test('multiple', () => {
-		expect(inline.mark('<s>text1</s>[<s>link1</s>](https://example.com/)<s>text2</s>[<s>link2</s>](https://example.com/)')).toBe(
-			'&lt;s>text1&lt;/s><a href="https://example.com/">&lt;s>link1&lt;/s></a><b class="c-domain">(example.com)</b>&lt;s>text2&lt;/s><a href="https://example.com/">&lt;s>link2&lt;/s></a><b class="c-domain">(example.com)</b>'
-		);
-	});
-
-	test('text in [', () => {
-		expect(inline.mark('[<s>text1</s>][<s>link1</s>](https://example.com/)[<s>text2</s>][<s>link2</s>](https://example.com/)')).toBe(
-			'[&lt;s>text1&lt;/s>]<a href="https://example.com/">&lt;s>link1&lt;/s></a><b class="c-domain">(example.com)</b>[&lt;s>text2&lt;/s>]<a href="https://example.com/">&lt;s>link2&lt;/s></a><b class="c-domain">(example.com)</b>'
-		);
-	});
-
 	test('URL &', () => {
-		expect(inline.mark('<s>text1</s>[<s>link1</s>](https://example.com/?foo=hoge&bar=piyo)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><a href="https://example.com/?foo=hoge&amp;bar=piyo">&lt;s>link1&lt;/s></a><b class="c-domain">(example.com)</b>&lt;s>text2&lt;/s>'
+		expect(inline.mark('text1[link1](https://example.com/?foo=hoge&bar=piyo)text2')).toBe(
+			'text1<a href="https://example.com/?foo=hoge&amp;bar=piyo">link1</a><b class="c-domain">(example.com)</b>text2'
 		);
 	});
 
 	test('URL text', () => {
-		expect(inline.mark('<s>text1</s>[https://example.com/](https://example.com/)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><a href="https://example.com/">https://example.com/</a>&lt;s>text2&lt;/s>'
-		);
+		expect(inline.mark('text1[https://example.com/](https://example.com/)text2')).toBe('text1<a href="https://example.com/">https://example.com/</a>text2');
 	});
 
 	test('icon', () => {
-		expect(inline.mark('<s>text1</s>[<s>link1</s>](https://github.com/)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><a href="https://github.com/">&lt;s>link1&lt;/s></a><img src="/image/icon/github.svg" alt="(GitHub)" width="16" height="16" class="c-link-icon"/>&lt;s>text2&lt;/s>'
+		expect(inline.mark('text1[link1](https://github.com/)text2')).toBe(
+			'text1<a href="https://github.com/">link1</a><img src="/image/icon/github.svg" alt="(GitHub)" width="16" height="16" class="c-link-icon"/>text2'
 		);
 	});
 
 	test('PDF', () => {
-		expect(inline.mark('<s>text1</s>[<s>link1</s>](https://example.com/foo.pdf)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><a href="https://example.com/foo.pdf">&lt;s>link1&lt;/s></a><img src="/image/icon/pdf.png" alt="(PDF)" width="16" height="16" class="c-link-icon"/><b class="c-domain">(example.com)</b>&lt;s>text2&lt;/s>'
+		expect(inline.mark('text1[link1](https://example.com/foo.pdf)text2')).toBe(
+			'text1<a href="https://example.com/foo.pdf">link1</a><img src="/image/icon/pdf.png" alt="(PDF)" width="16" height="16" class="c-link-icon"/><b class="c-domain">(example.com)</b>text2'
 		);
 	});
 
 	test('entry ID', () => {
-		expect(inline.mark('<s>text1</s>[<s>link1</s>](1)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><a href="/1">&lt;s>link1&lt;/s></a>&lt;s>text2&lt;/s>'
-		);
+		expect(inline.mark('text1[link1](1)text2')).toBe('text1<a href="/1">link1</a>text2');
 	});
 
 	test('amazon', () => {
-		expect(inline.mark('<s>text1</s>[<s>link1</s>](amazon:4065199816)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><a href="https://www.amazon.co.jp/dp/4065199816/ref=nosim?tag=w0s.jp-22">&lt;s>link1&lt;/s></a><img src="/image/icon/amazon.png" alt="(Amazon)" width="16" height="16" class="c-link-icon"/>&lt;s>text2&lt;/s>'
+		expect(inline.mark('text1[link1](amazon:4065199816)text2')).toBe(
+			'text1<a href="https://www.amazon.co.jp/dp/4065199816/ref=nosim?tag=w0s.jp-22">link1</a><img src="/image/icon/amazon.png" alt="(Amazon)" width="16" height="16" class="c-link-icon"/>text2'
 		);
 	});
 
 	test('section', () => {
-		expect(inline.mark('<s>text1</s>[<s>link1</s>](#section-1)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><a href="#section-1">&lt;s>link1&lt;/s></a>&lt;s>text2&lt;/s>'
-		);
+		expect(inline.mark('text1[link1](#section-1)text2')).toBe('text1<a href="#section-1">link1</a>text2');
 	});
 
 	test('invalid', () => {
-		expect(inline.mark('<s>text1</s>[<s>link1</s>](foo)<s>text2</s>')).toBe('&lt;s>text1&lt;/s><a>&lt;s>link1&lt;/s></a>&lt;s>text2&lt;/s>');
+		expect(inline.mark('text1[link1](foo)text2')).toBe('text1<a>link1</a>text2');
 	});
 });
 
 describe('quote', () => {
-	const inline = new MarkdownInline();
-
 	test('single', () => {
-		expect(inline.mark('<s>text1</s>{{<s>quote1</s>}}<s>text2</s>')).toBe('&lt;s>text1&lt;/s><q>&lt;s>quote1&lt;/s></q>&lt;s>text2&lt;/s>');
+		expect(inline.mark('text1{{quote1}}text2')).toBe('text1<q>quote1</q>text2');
 	});
 
 	test('multiple', () => {
-		expect(inline.mark('<s>text1</s>{{<s>quote1</s>}}<s>text2</s>{{<s>quote2</s>}}')).toBe(
-			'&lt;s>text1&lt;/s><q>&lt;s>quote1&lt;/s></q>&lt;s>text2&lt;/s><q>&lt;s>quote2&lt;/s></q>'
-		);
+		expect(inline.mark('text1{{quote1}}text2{{quote2}}')).toBe('text1<q>quote1</q>text2<q>quote2</q>');
+	});
+
+	test('open only', () => {
+		expect(inline.mark('text1{{text2')).toBe('text1{{text2');
 	});
 });
 
 describe('quote - meta', () => {
-	const inline = new MarkdownInline();
-
 	test('URL', () => {
-		expect(inline.mark('<s>text1</s>{{<s>quote1</s>}}(https://example.com/)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><a href="https://example.com/"><q cite="https://example.com/">&lt;s>quote1&lt;/s></q></a><b class="c-domain">(example.com)</b>&lt;s>text2&lt;/s>'
+		expect(inline.mark('text1{{quote1}}(https://example.com/)text2')).toBe(
+			'text1<a href="https://example.com/"><q cite="https://example.com/">quote1</q></a><b class="c-domain">(example.com)</b>text2'
 		);
 	});
 
 	test('ISBN', () => {
-		expect(inline.mark('<s>text1</s>{{<s>quote1</s>}}(978-4-06-519981-7)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><q cite="urn:ISBN:978-4-06-519981-7">&lt;s>quote1&lt;/s></q>&lt;s>text2&lt;/s>'
-		);
+		expect(inline.mark('text1{{quote1}}(978-4-06-519981-7)text2')).toBe('text1<q cite="urn:ISBN:978-4-06-519981-7">quote1</q>text2');
 	});
 
 	test('ISBN - invalid check digit', () => {
-		expect(inline.mark('<s>text1</s>{{<s>quote1</s>}}(978-4-06-519981-0)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><q>&lt;s>quote1&lt;/s></q>&lt;s>text2&lt;/s>'
-		);
+		expect(inline.mark('text1{{quote1}}(978-4-06-519981-0)text2')).toBe('text1<q>quote1</q>text2');
 	});
 
 	test('lang', () => {
-		expect(inline.mark('<s>text1</s>{{<s>quote1</s>}}(en)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><q lang="en">&lt;s>quote1&lt;/s></q>&lt;s>text2&lt;/s>'
-		);
+		expect(inline.mark('text1{{quote1}}(en)text2')).toBe('text1<q lang="en">quote1</q>text2');
 	});
 
 	test('quote - cite - URL & ISBN & lang', async () => {
-		expect(inline.mark('<s>text1</s>{{<s>quote1</s>}}(https://example.com/ 978-4-06-519981-7 en)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><a href="https://example.com/"><q lang="en" cite="https://example.com/">&lt;s>quote1&lt;/s></q></a><b class="c-domain">(example.com)</b>&lt;s>text2&lt;/s>'
+		expect(inline.mark('text1{{quote1}}(https://example.com/ 978-4-06-519981-7 en)text2')).toBe(
+			'text1<a href="https://example.com/"><q lang="en" cite="https://example.com/">quote1</q></a><b class="c-domain">(example.com)</b>text2'
 		);
 	});
 
 	test('empty', () => {
-		expect(inline.mark('<s>text1</s>{{<s>quote1</s>}}()<s>text2</s>')).toBe('&lt;s>text1&lt;/s><q>&lt;s>quote1&lt;/s></q>()&lt;s>text2&lt;/s>');
+		expect(inline.mark('text1{{quote1}}()text2')).toBe('text1<q>quote1</q>()text2');
 	});
 
 	test('multiple', () => {
-		expect(inline.mark('<s>text1</s>{{<s>quote1</s>}}(https://example.com/1)<s>text2</s>{{<s>quote2</s>}}(https://example.com/2)')).toBe(
-			'&lt;s>text1&lt;/s><a href="https://example.com/1"><q cite="https://example.com/1">&lt;s>quote1&lt;/s></q></a><b class="c-domain">(example.com)</b>&lt;s>text2&lt;/s><a href="https://example.com/2"><q cite="https://example.com/2">&lt;s>quote2&lt;/s></q></a><b class="c-domain">(example.com)</b>'
+		expect(inline.mark('text1{{quote1}}(https://example.com/1)text2{{<s>quote2</s>}}(https://example.com/2)')).toBe(
+			'text1<a href="https://example.com/1"><q cite="https://example.com/1">quote1</q></a><b class="c-domain">(example.com)</b>text2<a href="https://example.com/2"><q cite="https://example.com/2">&lt;s>quote2&lt;/s></q></a><b class="c-domain">(example.com)</b>'
 		);
 	});
 
 	test('multiple (meta, no meta)', () => {
-		expect(inline.mark('<s>text1</s>{{<s>quote1</s>}}<s>text2</s>{{<s>quote2</s>}}(https://example.com/)')).toBe(
-			'&lt;s>text1&lt;/s><q>&lt;s>quote1&lt;/s></q>&lt;s>text2&lt;/s><a href="https://example.com/"><q cite="https://example.com/">&lt;s>quote2&lt;/s></q></a><b class="c-domain">(example.com)</b>'
+		expect(inline.mark('text1{{quote1}}text2{{<s>quote2</s>}}(https://example.com/)')).toBe(
+			'text1<q>quote1</q>text2<a href="https://example.com/"><q cite="https://example.com/">&lt;s>quote2&lt;/s></q></a><b class="c-domain">(example.com)</b>'
 		);
 	});
 
 	test('multiple (no meta, meta)', () => {
-		expect(inline.mark('<s>text1</s>{{<s>quote1</s>}}(https://example.com/)<s>text2</s>{{<s>quote2</s>}}')).toBe(
-			'&lt;s>text1&lt;/s><a href="https://example.com/"><q cite="https://example.com/">&lt;s>quote1&lt;/s></q></a><b class="c-domain">(example.com)</b>&lt;s>text2&lt;/s><q>&lt;s>quote2&lt;/s></q>'
+		expect(inline.mark('text1{{quote1}}(https://example.com/)text2{{<s>quote2</s>}}')).toBe(
+			'text1<a href="https://example.com/"><q cite="https://example.com/">quote1</q></a><b class="c-domain">(example.com)</b>text2<q>&lt;s>quote2&lt;/s></q>'
 		);
 	});
 });
 
 describe('footnote', () => {
-	const inline = new MarkdownInline();
-
 	test('single', () => {
-		expect(inline.mark('<s>text1</s>((<s>footnote1</s>))<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><span class="c-annotate"><a href="#fn1" id="nt1" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[1]</a></span>&lt;s>text2&lt;/s>'
+		const footnote = new MarkdownInline();
+		expect(footnote.mark('text1((footnote1))text2')).toBe(
+			'text1<span class="c-annotate"><a href="#fn1" id="nt1" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[1]</a></span>text2'
 		);
-		expect(inline.footnotes.length).toBe(1);
+		expect(footnote.footnotes.length).toBe(1);
 	});
 
 	test('multiple', () => {
-		expect(inline.mark('<s>text1</s>((<s>footnote1</s>))<s>text2</s>((<s>footnote2</s>))')).toBe(
-			'&lt;s>text1&lt;/s><span class="c-annotate"><a href="#fn2" id="nt2" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[2]</a></span>&lt;s>text2&lt;/s><span class="c-annotate"><a href="#fn3" id="nt3" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[3]</a></span>'
+		const footnote = new MarkdownInline();
+		expect(footnote.mark('text1((footnote1))text2((footnote2))')).toBe(
+			'text1<span class="c-annotate"><a href="#fn1" id="nt1" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[1]</a></span>text2<span class="c-annotate"><a href="#fn2" id="nt2" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[2]</a></span>'
 		);
-		expect(inline.footnotes.length).toBe(3);
-	});
-});
-
-describe('mix', () => {
-	const inline = new MarkdownInline();
-
-	test('anchor & emphasis & code & quote & footnote', () => {
-		expect(inline.mark('<s>text1</s>[<s>link1</s>](https://example.com/)*<s>em1</s>*`<s>code1</s>`{{<s>quote1</s>}}((<s>footnote1</s>))<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><a href="https://example.com/">&lt;s>link1&lt;/s></a><b class="c-domain">(example.com)</b><em>&lt;s>em1&lt;/s></em><code>&lt;s>code1&lt;/s></code><q>&lt;s>quote1&lt;/s></q><span class="c-annotate"><a href="#fn1" id="nt1" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[1]</a></span>&lt;s>text2&lt;/s>'
-		);
+		expect(footnote.footnotes.length).toBe(2);
 	});
 
-	test('anchor > code', () => {
-		expect(inline.mark('<s>text1</s>[`<s>link1</s>`](https://example.com/)<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><a href="https://example.com/"><code>&lt;s>link1&lt;/s></code></a><b class="c-domain">(example.com)</b>&lt;s>text2&lt;/s>'
-		);
-	});
-
-	test('code > anchor', () => {
-		expect(inline.mark('<s>text1</s>`[<s>link1</s>](https://example.com/)`<s>text2</s>')).toBe(
-			'&lt;s>text1&lt;/s><code>[&lt;s>link1&lt;/s>](https://example.com/)</code>&lt;s>text2&lt;/s>'
-		);
+	test('open only', () => {
+		const footnote = new MarkdownInline();
+		expect(footnote.mark('text1((text2')).toBe('text1((text2');
+		expect(footnote.footnotes.length).toBe(0);
 	});
 });

--- a/packages/backend/node/__tests__/MarkdownInline.test.js
+++ b/packages/backend/node/__tests__/MarkdownInline.test.js
@@ -124,23 +124,23 @@ describe('quote - meta', () => {
 describe('footnote', () => {
 	test('single', () => {
 		const footnote = new MarkdownInline();
-		expect(footnote.mark('text1((footnote1))text2')).toBe(
-			'text1<span class="c-annotate"><a href="#fn1" id="nt1" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[1]</a></span>text2'
+		expect(footnote.mark('text1[^f1]text2')).toBe(
+			'text1<span class="c-annotate"><a href="#footnote-f1" id="footnote-ref-f1" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[1]</a></span>text2'
 		);
-		expect(footnote.footnotes.length).toBe(1);
+		expect(footnote.footnotes.size).toBe(1);
 	});
 
 	test('multiple', () => {
 		const footnote = new MarkdownInline();
-		expect(footnote.mark('text1((footnote1))text2((footnote2))')).toBe(
-			'text1<span class="c-annotate"><a href="#fn1" id="nt1" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[1]</a></span>text2<span class="c-annotate"><a href="#fn2" id="nt2" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[2]</a></span>'
+		expect(footnote.mark('text1[^f1]text2[^f2]')).toBe(
+			'text1<span class="c-annotate"><a href="#footnote-f1" id="footnote-ref-f1" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[1]</a></span>text2<span class="c-annotate"><a href="#footnote-f2" id="footnote-ref-f2" is="w0s-tooltip-trigger" data-tooltip-label="脚注" data-tooltip-class="p-tooltip" data-tooltip-close-text="閉じる" data-tooltip-close-image-src="/image/tooltip-close.svg">[2]</a></span>'
 		);
-		expect(footnote.footnotes.length).toBe(2);
+		expect(footnote.footnotes.size).toBe(2);
 	});
 
 	test('open only', () => {
 		const footnote = new MarkdownInline();
-		expect(footnote.mark('text1((text2')).toBe('text1((text2');
-		expect(footnote.footnotes.length).toBe(0);
+		expect(footnote.mark('text1[^text2')).toBe('text1[^text2');
+		expect(footnote.footnotes.size).toBe(0);
 	});
 });

--- a/packages/backend/node/src/markdown/Markdown.ts
+++ b/packages/backend/node/src/markdown/Markdown.ts
@@ -1480,7 +1480,7 @@ export default class Markdown {
 			const textElement = this.#document.createElement('span');
 			textElement.className = 'p-footnotes__text';
 			textElement.id = Footnote.getId(id);
-			textElement.insertAdjacentHTML('beforeend', footnote);
+			textElement.insertAdjacentHTML('beforeend', this.#inline.mark(footnote, { footnote: false }));
 			liElement.appendChild(textElement);
 
 			index += 1;

--- a/packages/backend/node/src/markdown/config.ts
+++ b/packages/backend/node/src/markdown/config.ts
@@ -52,4 +52,5 @@ export const regexp = {
 	entryId: '[1-9][0-9]*',
 	asin: '[0-9A-Z]{10}',
 	youtubeId: '[-_a-zA-Z0-9]+',
+	footnoteId: '[-_a-zA-Z0-9]+',
 };

--- a/packages/backend/node/src/markdown/lib/Footnote.ts
+++ b/packages/backend/node/src/markdown/lib/Footnote.ts
@@ -1,12 +1,23 @@
 export default class Footnote {
 	/**
-	 * 注釈要素の ID を生成する
+	 * 脚注要素の ID を生成する
 	 *
-	 * @param {number} no - 注釈連番
+	 * @param {string} id - 脚注 ID
 	 *
-	 * @returns {string} 注釈要素の ID
+	 * @returns {string} 脚注要素の ID
 	 */
-	static getId(no: number): string {
-		return String(no);
+	static getId(id: string): string {
+		return `footnote-${id}`;
+	}
+
+	/**
+	 * 脚注参照要素の ID を生成する
+	 *
+	 * @param {string} id - 脚注 ID
+	 *
+	 * @returns {string} 脚注参照要素の ID
+	 */
+	static getReferenceId(id: string): string {
+		return `footnote-ref-${id}`;
 	}
 }

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -385,6 +385,10 @@
 									<th scope="row">$amazon:<b class="u-red">␣</b>ASIN<small>（半角スペース区切りで任意数）</small></th>
 									<td>Amazon 商品</td>
 								</tr>
+								<tr>
+									<th scope="row">[^ID]:<b class="u-red">␣</b>脚注</th>
+									<td>脚注</td>
+								</tr>
 							</tbody>
 							<tbody>
 								<tr>
@@ -404,7 +408,7 @@
 									<td>Amazon アフィリエイトリンク（<code>a</code>）</td>
 								</tr>
 								<tr>
-									<th scope="row">**強調**</th>
+									<th scope="row">*強調*</th>
 									<td>強調（<code>em</code>）</td>
 								</tr>
 								<tr>
@@ -416,8 +420,8 @@
 									<td>インラインレベルの引用（<code>q</code>）</td>
 								</tr>
 								<tr>
-									<th scope="row">((注釈文))</th>
-									<td>注釈文</td>
+									<th scope="row">[^ID]</th>
+									<td>脚注</td>
 								</tr>
 							</tbody>
 						</table>


### PR DESCRIPTION
従来

```markdown
normal text ((footnote text)) normal text
```

変更後

```markdown
normal text [^1] normal text

[^1]: footnote text
```