### PR TITLE
画像サイズの桁数ミス修正

### DIFF
--- a/packages/backend/node/src/markdown/Markdown.ts
+++ b/packages/backend/node/src/markdown/Markdown.ts
@@ -518,7 +518,7 @@ export default class Markdown {
 							let imageWidth: number | undefined;
 							let imageHeight: number | undefined;
 							metas?.split(' ').forEach((meta) => {
-								if (/^[1-9][0-9]{2,3}x[1-9][0-9]{2,3}$/.test(meta)) {
+								if (/^[1-9][0-9]{1,2}x[1-9][0-9]{1,2}$/.test(meta)) {
 									/* 画像サイズ */
 									const sizes = meta.split('x');
 									imageWidth = Number(sizes.at(0));


### PR DESCRIPTION
#286 のバグ修正

古い商品などで画像サイズが2桁（99px以下）の時の判定バグ