### PR TITLE
Amazon 商品のデフォルト画像（noimage）がリンク切れになっていたバグを修正

### DIFF
--- a/packages/backend/node/src/markdown/Markdown.ts
+++ b/packages/backend/node/src/markdown/Markdown.ts
@@ -1437,7 +1437,7 @@ export default class Markdown {
 				dpImageElement.setAttribute('height', String(image.height));
 			}
 		} else {
-			dpImageElement.setAttribute('src', '/image/amazon_noimage.svg');
+			dpImageElement.setAttribute('src', '/image/entry/amazon-noimage.svg');
 			dpImageElement.setAttribute('width', '113');
 			dpImageElement.setAttribute('height', '160');
 		}

--- a/packages/frontend/image/image/entry/amazon-noimage.svg
+++ b/packages/frontend/image/image/entry/amazon-noimage.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="113" height="160" viewBox="0 0 113 160">
+<style type="text/css">
+.frame {
+	fill: #fff;
+	stroke: #999;
+	stroke-width: 2;
+}
+
+text {
+	fill: #767676;
+	font: 16px sans-serif;
+}
+</style>
+<rect width="100%" height="100%" class="frame"/>
+<text x="50%" y="50%" text-anchor="middle" dominant-baseline="central">No Image</text>
+</svg>


### PR DESCRIPTION
現状はたまたま画像なしの商品は記事で使用していないので実際にリンク切れが生じることはなかった。