### PR TITLE
埋め込みツイートの Markdown 構文変更

### DIFF
--- a/packages/backend/node/@types/api.d.ts
+++ b/packages/backend/node/@types/api.d.ts
@@ -3,6 +3,7 @@ declare namespace BlogApi {
 	/* 本文プレビュー */
 	interface Preview {
 		html: string;
+		tweetExist: boolean;
 	}
 
 	/* ツイート情報取得 */

--- a/packages/backend/node/src/controller/api/PreviewController.ts
+++ b/packages/backend/node/src/controller/api/PreviewController.ts
@@ -29,6 +29,7 @@ export default class PreviewController extends Controller implements ControllerI
 
 		const responseJson: BlogApi.Preview = {
 			html: await markdown.toHtml(requestQuery.markdown),
+			tweetExist: markdown.isTweetExit(),
 		};
 
 		res.status(200).json(responseJson);

--- a/packages/backend/node/src/markdown/config.ts
+++ b/packages/backend/node/src/markdown/config.ts
@@ -50,7 +50,8 @@ export const regexp = {
 	absoluteUrl: "https?://[-_.!~*'()a-zA-Z0-9;/?:@&=+$,%#]+",
 	isbn: '(978|979)-[0-9]{1,5}-[0-9]{1,7}-[0-9]{1,7}-[0-9]|[0-9]{1,5}-[0-9]{1,7}-[0-9]{1,7}-[0-9X]',
 	entryId: '[1-9][0-9]*',
+	footnoteId: '[-_a-zA-Z0-9]+',
 	asin: '[0-9A-Z]{10}',
 	youtubeId: '[-_a-zA-Z0-9]+',
-	footnoteId: '[-_a-zA-Z0-9]+',
+	tweetId: '[1-9][0-9]*',
 };

--- a/packages/frontend/public/script/_src/admin.ts
+++ b/packages/frontend/public/script/_src/admin.ts
@@ -50,18 +50,14 @@ const messagePreviewElement = document.getElementById('message-preview'); // 本
 const selectImageElement = <HTMLTemplateElement | null>document.getElementById('select-image');
 const selectImageErrorElement = <HTMLTemplateElement | null>document.getElementById('select-image-error');
 if (messageCtrlElement !== null && selectImageElement !== null && selectImageErrorElement !== null && messagePreviewElement !== null) {
-	const messageImage = new MessageImage(messageCtrlElement, selectImageElement, selectImageErrorElement);
 	const preview = new Preview(messageCtrlElement, messagePreviewElement);
+	const messageImage = new MessageImage(messageCtrlElement, selectImageElement, selectImageErrorElement);
 
-	await messageImage.exec();
-	await preview.exec();
+	const exec = async (): Promise<void> => {
+		await Promise.all([preview.exec(), messageImage.exec()]);
+	};
 
-	messageCtrlElement.addEventListener(
-		'change',
-		async () => {
-			await messageImage.exec();
-			await preview.exec();
-		},
-		{ passive: true }
-	);
+	exec();
+
+	messageCtrlElement.addEventListener('change', exec, { passive: true });
 }

--- a/packages/frontend/public/script/_src/unique/MessageImage.ts
+++ b/packages/frontend/public/script/_src/unique/MessageImage.ts
@@ -75,11 +75,9 @@ export default class MessageImage {
 				}
 				case '$': {
 					if (line.startsWith('$tweet: ')) {
-						const matchGroups = line.match(/^\$tweet: (?<ids>[0-9][ 0-9]*)$/)?.groups;
-						if (matchGroups !== undefined) {
-							matchGroups['ids']?.split(' ').forEach((tweetId) => {
-								tweetIds.add(tweetId);
-							});
+						const matchGroups = line.match(/^\$tweet: (?<id>[1-9][0-9]*)$/)?.groups;
+						if (matchGroups !== undefined && matchGroups['id'] !== undefined) {
+							tweetIds.add(matchGroups['id']);
 						}
 					} else if (line.startsWith('$amazon: ')) {
 						const matchGroups = line.match(/^\$amazon: (?<asin>[0-9A-Z]{10}) (?<title>[^<>]+)( <(?<metas>.+)>)?$/)?.groups;

--- a/packages/frontend/public/script/_src/unique/Preview.ts
+++ b/packages/frontend/public/script/_src/unique/Preview.ts
@@ -26,15 +26,20 @@ export default class Preview {
 			method: 'POST',
 			body: new URLSearchParams(<string[][]>[...formData]),
 		});
-		try {
-			if (!response.ok) {
-				throw new Error(`"${response.url}" is ${response.status} ${response.statusText}`);
-			}
-			const responseJson = await response.json();
 
-			this.#previewElement.innerHTML = responseJson.html;
-		} catch (e) {
-			this.#previewElement.textContent = e instanceof Error ? e.message : 'Error';
+		if (!response.ok) {
+			this.#previewElement.textContent = `"${response.url}" is ${response.status} ${response.statusText}`;
+		}
+		const responseJson: {
+			html: string;
+			tweetExist: boolean;
+		} = await response.json();
+
+		this.#previewElement.innerHTML = responseJson.html;
+
+		if (responseJson.tweetExist) {
+			// @ts-expect-error: ts(2339)
+			window.twttr.widgets.load(this.#previewElement); // https://developer.twitter.com/en/docs/twitter-for-websites/javascript-api/guides/scripting-loading-and-initialization
 		}
 	}
 }

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -378,7 +378,7 @@
 									<td>YouTube 動画</td>
 								</tr>
 								<tr>
-									<th scope="row">$tweet:<b class="u-red">␣</b>ID<small>（半角スペース区切りで任意数）</small></th>
+									<th scope="row">$tweet:<b class="u-red">␣</b>ID</th>
 									<td>埋め込みツイート</td>
 								</tr>
 								<tr>

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -8,6 +8,7 @@
 		<link rel="alternate stylesheet" href="/style/layout_reader.css" title="リーダー表示" />
 		<link rel="stylesheet" href="/style/layout_reader.css" media="print" />
 
+		<script src="https://platform.twitter.com/widgets.js" defer=""></script>
 		<script src="/script/admin.mjs" type="module"></script>
 
 		<title>富永日記帳: 記事投稿</title>


### PR DESCRIPTION
将来的にメタ情報（リプライ表示の可否とか）を設定できるよう、一行に1ツイートのみとする。

旧構文

```
$tweet:␣Tweet ID（半角スペース区切りで任意数）
```

新構文

```
$tweet:␣Tweet ID
```