### PR TITLE
フィードに `<summary>` を追加

### DIFF
--- a/packages/backend/node/@types/view.d.ts
+++ b/packages/backend/node/@types/view.d.ts
@@ -18,6 +18,7 @@ declare namespace BlogView {
 	interface FeedEntry {
 		id: number;
 		title: string;
+		description: string | null;
 		message: string;
 		updated_at: import('dayjs').Dayjs;
 		update: boolean;

--- a/packages/backend/node/src/controller/PostController.ts
+++ b/packages/backend/node/src/controller/PostController.ts
@@ -271,6 +271,7 @@ export default class PostController extends Controller implements ControllerInte
 					entriesView.add({
 						id: entry.id,
 						title: entry.title,
+						description: entry.description,
 						message: (await new Markdown().toHtml(entry.message)).value.toString(),
 						updated_at: dayjs(entry.updated_at ?? entry.created_at),
 						update: Boolean(entry.updated_at),

--- a/views/feed/atom.ejs
+++ b/views/feed/atom.ejs
@@ -13,11 +13,11 @@
 	<%_ for (const entry of entries) { _%>
 	<entry>
 		<title><%_ if (entry.update) { _%>【更新】<%_ } _%><%= entry.title %></title>
+		<%_ if (entry.description !== null) { _%><summary><%= entry.description %></summary><%_ } _%>
 		<id>tag:blog.w0s.jp,<%= entry.updated_at.format('YYYY-MM-DD') %>:/<%= entry.id %></id>
 		<link href="/<%= entry.id %>" type="text/html" />
 		<updated><%= entry.updated_at.format('YYYY-MM-DDTHH:mm:ssZ') %></updated>
 		<content type="xhtml" xml:base="/<%= entry.id %>">
-			<!-- prettier-ignore -->
 			<div xmlns="http://www.w3.org/1999/xhtml"><%- entry.message %></div>
 		</content>
 	</entry>


### PR DESCRIPTION
#302 で自動ツイート機能を削除し、Zapier 経由で投稿することにした。
記事概要をツイートに含めたいため、Atom フィードのエントリーに `<summary>` 要素を追加する。