### PR TITLE
記事タイトルの  `<h1>` 内の `<code>` が色付けされていたバグを修正

### DIFF
--- a/packages/frontend/style/foundation/_elements.css
+++ b/packages/frontend/style/foundation/_elements.css
@@ -67,14 +67,13 @@ code {
 	background-color: var(--color-ultralightgreen);
 	padding-block: 0.25em;
 	color: var(--color-green);
-	font-family: var(--font-monospace);
-}
 
-:where(hgroup, pre, a) code {
-	border-radius: 0;
-	background-color: transparent;
-	padding-block: 0;
-	color: inherit;
+	:where(h1, h2, h3, h4, h5, h6, hgroup, pre, a) & {
+		border-radius: 0;
+		background-color: transparent;
+		padding-block: 0;
+		color: inherit;
+	}
 }
 
 q {


### PR DESCRIPTION
#304 の対応漏れ