### PR TITLE
ガワのマークアップ変更（主に見出し回り）

### DIFF
--- a/packages/frontend/style/admin.css
+++ b/packages/frontend/style/admin.css
@@ -15,6 +15,7 @@
 @import url("object/component/_form.css") layer(component);
 @import url("object/component/_form-search.css") layer(component);
 @import url("object/component/_layout.css") layer(component);
+@import url("object/component/_sidebar.css") layer(component);
 
 /* Object - Project */
 @import url("object/project/_header.css") layer(project);

--- a/packages/frontend/style/blog.css
+++ b/packages/frontend/style/blog.css
@@ -14,6 +14,7 @@
 @import url("object/component/_embedded.css") layer(component);
 @import url("object/component/_form-search.css") layer(component);
 @import url("object/component/_layout.css") layer(component);
+@import url("object/component/_sidebar.css") layer(component);
 
 /* Object - Project */
 @import url("object/project/_header.css") layer(project);

--- a/packages/frontend/style/object/component/_sidebar.css
+++ b/packages/frontend/style/object/component/_sidebar.css
@@ -1,0 +1,81 @@
+/* ==============================
+ *   サイドバー
+ * ============================== */
+
+/* ===== リンクリスト ===== */
+.c-sidebar-link {
+	--_padding-block: 0.5em;
+	--_padding-inline: 0.5em;
+	--_min-block-size: auto;
+	--_bg-color: var(--color-verylightblue);
+
+	& a {
+		display: block;
+		contain: content;
+		outline-width: var(--outline-width-bold);
+		outline-offset: -1px;
+		background: var(--_bg-color);
+		padding: var(--_padding-block) var(--_padding-inline);
+		min-block-size: var(--_min-block-size);
+		font-size: calc(100% / var(--font-ratio-1));
+
+		&:any-link {
+			--_bg-color: var(--color-white);
+			--_icon-color: var(--color-lightgray); /* アイコンの色 */
+			--_icon-inline-size: 0.67em; /* アイコンの幅 */
+			--_icon-block-size: 1em; /* アイコンの高さ */
+			--_icon-gap: 0.75em; /* テキストとアイコンの間隔 */
+
+			padding-inline-end: calc(var(--_icon-gap) + var(--_icon-inline-size) + var(--_padding-inline));
+			text-decoration: none;
+
+			&::after {
+				position: absolute;
+				clip-path: var(--shape-link-arrow);
+				inset-block-start: calc(50% - var(--_icon-block-size) / 2);
+				inset-inline-end: var(--_padding-inline);
+				border-block-start: var(--_icon-block-size) solid var(--_icon-color);
+				inline-size: var(--_icon-inline-size);
+				content: "";
+			}
+
+			&:hover {
+				--_bg-color: var(--color-lightyellow);
+				--_icon-color: var(--color-gray);
+			}
+		}
+	}
+
+	& > li {
+		& + li {
+			border-block-start: 1px dotted var(--color-border-dark);
+		}
+
+		/* 奇数行 */
+		&:nth-child(2n + 1) {
+			& a {
+				&:any-link {
+					--_bg-color: var(--color-bg-superlight);
+
+					&:hover {
+						--_bg-color: var(--color-lightyellow);
+					}
+				}
+			}
+		}
+	}
+
+	/* 記事 */
+	&.-entry {
+		--_min-block-size: 2em;
+	}
+
+	/* カテゴリー */
+	&.-category {
+		--_padding-block: 0.25em;
+	}
+}
+
+.c-sidebar-link__icon {
+	margin-inline-start: 0.5em;
+}

--- a/packages/frontend/style/object/project/_footer.css
+++ b/packages/frontend/style/object/project/_footer.css
@@ -46,3 +46,6 @@
 		display: block;
 	}
 }
+
+.p-footer-ads__hdg {
+}

--- a/packages/frontend/style/object/project/_sidebar.css
+++ b/packages/frontend/style/object/project/_sidebar.css
@@ -68,11 +68,11 @@
 	font-size: calc(100% / var(--font-ratio-1));
 }
 
-/* ===== カテゴリータブ ===== */
-.p-sidebar-category-tab {
+/* ===== カテゴリー ===== */
+.p-sidebar-categories {
 }
 
-.p-sidebar-category-tab__item {
+.p-sidebar-categories__item {
 	--_padding-block: 0.6em;
 	--_border-color: var(--color-border-dark);
 	--_border-radius-top: 0px;
@@ -122,20 +122,20 @@
 	}
 }
 
-.p-sidebar-category-tab__panel {
+.p-sidebar-categories__panel {
 	border: solid var(--color-border-dark);
 	border-width: 0 1px 1px;
 }
 
-/* ===== 最近の記事 ===== */
-.p-sidebar-newly-entry {
+/* ===== 記事一覧 ===== */
+.p-sidebar-entries {
 	--_heading-offset: calc(-0.5em * var(--line-height-narrow));
 
 	border: 1px solid var(--color-border-dark);
 	border-radius: var(--border-radius-normal) var(--border-radius-normal) 0 0;
 }
 
-.p-sidebar-newly-entry__hdg {
+.p-sidebar-entries__hdg {
 	display: inline-block;
 	position: relative;
 	margin-inline: 10px;
@@ -144,7 +144,7 @@
 	padding: 0 0.5em;
 }
 
-.p-sidebar-newly-entry__link {
+.p-sidebar-entries__link {
 	margin-block-start: var(--_heading-offset);
 }
 

--- a/packages/frontend/style/object/project/_sidebar.css
+++ b/packages/frontend/style/object/project/_sidebar.css
@@ -21,12 +21,15 @@
 	inset-block-start: var(--_heading-offset);
 	background: var(--page-bg-color);
 	padding: 0 0.5em;
+
+	& + * {
+		margin-block-start: calc(10px + var(--_heading-offset));
+	}
 }
 
 .p-sidebar-profile__info {
 	display: flow-root; /* for Safari */
 	contain: layout;
-	margin-block-start: calc(10px + var(--_heading-offset));
 }
 
 .p-sidebar-profile__address {
@@ -142,86 +145,8 @@
 	inset-block-start: var(--_heading-offset);
 	background: var(--page-bg-color);
 	padding: 0 0.5em;
-}
 
-.p-sidebar-entries__link {
-	margin-block-start: var(--_heading-offset);
-}
-
-/* ===== リンクリスト ===== */
-.p-sidebar-links {
-	--_padding-block: 0.5em;
-	--_padding-inline: 0.5em;
-	--_min-block-size: auto;
-	--_bg-color: var(--color-verylightblue);
-
-	& a {
-		display: block;
-		contain: content;
-		outline-width: var(--outline-width-bold);
-		outline-offset: -1px;
-		background: var(--_bg-color);
-		padding: var(--_padding-block) var(--_padding-inline);
-		min-block-size: var(--_min-block-size);
-		font-size: calc(100% / var(--font-ratio-1));
-
-		&:any-link {
-			--_bg-color: var(--color-white);
-			--_icon-color: var(--color-lightgray); /* アイコンの色 */
-			--_icon-inline-size: 0.67em; /* アイコンの幅 */
-			--_icon-block-size: 1em; /* アイコンの高さ */
-			--_icon-gap: 0.75em; /* テキストとアイコンの間隔 */
-
-			padding-inline-end: calc(var(--_icon-gap) + var(--_icon-inline-size) + var(--_padding-inline));
-			text-decoration: none;
-
-			&::after {
-				position: absolute;
-				clip-path: var(--shape-link-arrow);
-				inset-block-start: calc(50% - var(--_icon-block-size) / 2);
-				inset-inline-end: var(--_padding-inline);
-				border-block-start: var(--_icon-block-size) solid var(--_icon-color);
-				inline-size: var(--_icon-inline-size);
-				content: "";
-			}
-
-			&:hover {
-				--_bg-color: var(--color-lightyellow);
-				--_icon-color: var(--color-gray);
-			}
-		}
+	& + * {
+		margin-block-start: var(--_heading-offset);
 	}
-
-	& > li {
-		& + li {
-			border-block-start: 1px dotted var(--color-border-dark);
-		}
-
-		/* 奇数行 */
-		&:nth-child(2n + 1) {
-			& a {
-				&:any-link {
-					--_bg-color: var(--color-bg-superlight);
-
-					&:hover {
-						--_bg-color: var(--color-lightyellow);
-					}
-				}
-			}
-		}
-	}
-
-	/* カテゴリー */
-	&.-category {
-		--_padding-block: 0.25em;
-	}
-
-	/* 記事 */
-	&.-entry {
-		--_min-block-size: 2em;
-	}
-}
-
-.p-sidebar-links__icon {
-	margin-inline-start: 0.5em;
 }

--- a/views/_include/footer.ejs
+++ b/views/_include/footer.ejs
@@ -9,7 +9,9 @@
 	</div>
 
 	<div class="l-footer__ads">
-		<section class="p-footer-ads" aria-label="広告">
+		<section class="p-footer-ads">
+			<h2 class="p-footer-ads__hdg">広告</h2>
+
 			<ins class="adsbygoogle js-ads-google" data-ad-format="autorelaxed" data-ad-client="ca-pub-3297715785193216" data-ad-slot="5374501322"></ins>
 		</section>
 	</div>

--- a/views/_include/header.ejs
+++ b/views/_include/header.ejs
@@ -1,18 +1,21 @@
 <header id="header" class="l-header">
 	<div class="l-header__main">
 		<div class="l-header__site">
-			<div class="p-header-site">
-				<%_ if (heading) { _%>
-					<%_ if (pagePathAbsoluteUrl === '/') { _%>
-					<h1 class="p-header-site__name"><a aria-current="page">富永日記帳</a></h1>
-					<%_ } else { _%>
-					<h1 class="p-header-site__name"><a href="/">富永日記帳</a></h1>
-					<%_ } _%>
+			<%_ if (heading) { _%>
+			<hgroup class="p-header-site">
+				<%_ if (pagePathAbsoluteUrl === '/') { _%>
+				<h1 class="p-header-site__name"><a aria-current="page">富永日記帳</a></h1>
 				<%_ } else { _%>
-				<div class="p-header-site__name"><a href="/">富永日記帳</a></div>
+				<h1 class="p-header-site__name"><a href="/">富永日記帳</a></h1>
 				<%_ } _%>
 				<p class="p-header-site__summary">ウェブ技術や東急電車、久米田康治作品の話を中心としたブログ</p>
+			</hgroup>
+			<%_ } else { _%>
+			<div class="p-header-site">
+				<div class="p-header-site__name"><a href="/">富永日記帳</a></div>
+				<p class="p-header-site__summary">ウェブ技術や東急電車、久米田康治作品の話を中心としたブログ</p>
 			</div>
+			<%_ } _%>
 		</div>
 		<div class="l-header__nav">
 			<div class="p-header-nav">

--- a/views/_include/sidebar.ejs
+++ b/views/_include/sidebar.ejs
@@ -1,6 +1,6 @@
 <div id="sidebar" class="l-sidebar">
-	<section class="p-sidebar-profile" aria-labelledby="sidebar-profile-heading">
-		<h2 class="p-sidebar-profile__hdg" id="sidebar-profile-heading">プロフィール</h2>
+	<section class="p-sidebar-profile">
+		<h2 class="p-sidebar-profile__hdg">プロフィール</h2>
 
 		<div class="p-sidebar-profile__info">
 			<address class="p-sidebar-profile__address">
@@ -43,8 +43,8 @@
 		</ul>
 	</section>
 
-	<section class="p-sidebar-categories" aria-label="記事カテゴリ一覧">
-		<w0s-tab tablist-label="カテゴリ" storage-key="sidebar-category-tab">
+	<section class="p-sidebar-categories">
+		<w0s-tab tablist-label="記事カテゴリー" storage-key="sidebar-category-tab">
 			<%_ for (const [group_name, ] of entryCountOfCategoryList) { _%>
 			<a href="#<%= group_name %>" slot="tab" class="p-sidebar-categories__item"><%= group_name %></a>
 			<%_ } _%><%_ for (const [group_name, countDataList] of entryCountOfCategoryList) { _%>
@@ -84,8 +84,8 @@
 		</w0s-tab>
 	</section>
 
-	<section class="p-sidebar-entries" aria-labelledby="sidebar-newly-entries-heading">
-		<h2 class="p-sidebar-entries__hdg" id="sidebar-newly-entries-heading">最近の記事</h2>
+	<section class="p-sidebar-entries">
+		<h2 class="p-sidebar-entries__hdg">最近の記事</h2>
 
 		<%_ if (typeof(requestQuery.entry_id) !== 'undefined') { _%>
 		<ul class="c-sidebar-link -entry">

--- a/views/_include/sidebar.ejs
+++ b/views/_include/sidebar.ejs
@@ -43,12 +43,12 @@
 		</ul>
 	</section>
 
-	<section class="p-sidebar-category-tab" aria-label="記事カテゴリ一覧">
+	<section class="p-sidebar-categories" aria-label="記事カテゴリ一覧">
 		<w0s-tab tablist-label="カテゴリ" storage-key="sidebar-category-tab">
 			<%_ for (const [group_name, ] of entryCountOfCategoryList) { _%>
-			<a href="#<%= group_name %>" slot="tab" class="p-sidebar-category-tab__item"><%= group_name %></a>
+			<a href="#<%= group_name %>" slot="tab" class="p-sidebar-categories__item"><%= group_name %></a>
 			<%_ } _%><%_ for (const [group_name, countDataList] of entryCountOfCategoryList) { _%>
-			<div slot="tabpanel" class="p-sidebar-category-tab__panel" id="<%= group_name %>">
+			<div slot="tabpanel" class="p-sidebar-categories__panel" id="<%= group_name %>">
 				<%_ if (typeof(requestQuery.category_name) !== 'undefined') { _%>
 				<ul class="p-sidebar-links -category">
 					<%_ for (const countData of countDataList) { _%>
@@ -84,10 +84,10 @@
 		</w0s-tab>
 	</section>
 
-	<section class="p-sidebar-newly-entry" aria-labelledby="sidebar-newly-entries-heading">
-		<h2 class="p-sidebar-newly-entry__hdg" id="sidebar-newly-entries-heading">最近の記事</h2>
+	<section class="p-sidebar-entries" aria-labelledby="sidebar-newly-entries-heading">
+		<h2 class="p-sidebar-entries__hdg" id="sidebar-newly-entries-heading">最近の記事</h2>
 
-		<div class="p-sidebar-newly-entry__link">
+		<div class="p-sidebar-entries__link">
 			<%_ if (typeof(requestQuery.entry_id) !== 'undefined') { _%>
 			<ul class="p-sidebar-links -entry">
 				<%_ for (const newlyEntry of newlyEntries) { _%>

--- a/views/_include/sidebar.ejs
+++ b/views/_include/sidebar.ejs
@@ -50,30 +50,30 @@
 			<%_ } _%><%_ for (const [group_name, countDataList] of entryCountOfCategoryList) { _%>
 			<div slot="tabpanel" class="p-sidebar-categories__panel" id="<%= group_name %>">
 				<%_ if (typeof(requestQuery.category_name) !== 'undefined') { _%>
-				<ul class="p-sidebar-links -category">
+				<ul class="c-sidebar-link -category">
 					<%_ for (const countData of countDataList) { _%>
 					<li>
 						<%_ if (requestQuery.category_name === countData.category_name) { _%>
 						<a aria-current="page">
 							<%= countData.category_name %>
-							<span class="p-sidebar-links__icon c-entry-count"><b class="c-entry-count__num"><%= countData.count %></b>件</span>
+							<span class="c-sidebar-link__icon c-entry-count"><b class="c-entry-count__num"><%= countData.count %></b>件</span>
 						</a>
 						<%_ } else { _%>
 						<a href="/category/<%= encodeURI(countData.category_name) %>">
 							<%= countData.category_name %>
-							<span class="p-sidebar-links__icon c-entry-count"><b class="c-entry-count__num"><%= countData.count %></b>件</span>
+							<span class="c-sidebar-link__icon c-entry-count"><b class="c-entry-count__num"><%= countData.count %></b>件</span>
 						</a>
 						<%_ } _%>
 					</li>
 					<%_ } _%>
 				</ul>
 				<%_ } else { _%>
-				<ul class="p-sidebar-links -category">
+				<ul class="c-sidebar-link -category">
 					<%_ for (const countData of countDataList) { _%>
 					<li>
 						<a href="/category/<%= encodeURI(countData.category_name) %>">
 							<%= countData.category_name %>
-							<span class="p-sidebar-links__icon c-entry-count"><b class="c-entry-count__num"><%= countData.count %></b>件</span>
+							<span class="c-sidebar-link__icon c-entry-count"><b class="c-entry-count__num"><%= countData.count %></b>件</span>
 						</a>
 					</li>
 					<%_ } _%>
@@ -87,28 +87,26 @@
 	<section class="p-sidebar-entries" aria-labelledby="sidebar-newly-entries-heading">
 		<h2 class="p-sidebar-entries__hdg" id="sidebar-newly-entries-heading">最近の記事</h2>
 
-		<div class="p-sidebar-entries__link">
-			<%_ if (typeof(requestQuery.entry_id) !== 'undefined') { _%>
-			<ul class="p-sidebar-links -entry">
-				<%_ for (const newlyEntry of newlyEntries) { _%>
-				<li>
-					<%_ if (requestQuery.entry_id === newlyEntry.id) { _%>
-					<a aria-current="page"><%- newlyEntry.title %></a>
-					<%_ } else { _%>
-					<a href="/<%= newlyEntry.id %>"><%- newlyEntry.title %></a>
-					<%_ } _%>
-				</li>
+		<%_ if (typeof(requestQuery.entry_id) !== 'undefined') { _%>
+		<ul class="c-sidebar-link -entry">
+			<%_ for (const newlyEntry of newlyEntries) { _%>
+			<li>
+				<%_ if (requestQuery.entry_id === newlyEntry.id) { _%>
+				<a aria-current="page"><%- newlyEntry.title %></a>
+				<%_ } else { _%>
+				<a href="/<%= newlyEntry.id %>"><%- newlyEntry.title %></a>
 				<%_ } _%>
-			</ul>
-			<%_ } else { _%>
-			<ul class="p-sidebar-links -entry">
-				<%_ for (const newlyEntry of newlyEntries) { _%>
-				<li>
-					<a href="/<%= newlyEntry.id %>"><%- newlyEntry.title %></a>
-				</li>
-				<%_ } _%>
-			</ul>
+			</li>
 			<%_ } _%>
-		</div>
+		</ul>
+		<%_ } else { _%>
+		<ul class="c-sidebar-link -entry">
+			<%_ for (const newlyEntry of newlyEntries) { _%>
+			<li>
+				<a href="/<%= newlyEntry.id %>"><%- newlyEntry.title %></a>
+			</li>
+			<%_ } _%>
+		</ul>
+		<%_ } _%>
 	</section>
 </div>


### PR DESCRIPTION
- ランドマークの乱用をやめる
- アウトラインアルゴリズムの廃止に伴い `<hgroup>` はもう使って問題ない
