### PR TITLE
画像キャプション部分の Markdown を認識するように

### DIFF
--- a/packages/backend/node/__tests__/MarkdownBlock.test.js
+++ b/packages/backend/node/__tests__/MarkdownBlock.test.js
@@ -907,7 +907,7 @@ text1
 });
 
 describe('Image', () => {
-	test('normal', async () => {
+	test('JPEG', async () => {
 		const markdown = new Markdown();
 		expect(
 			format(
@@ -934,15 +934,73 @@ describe('Image', () => {
 		);
 	});
 
-	test('multi line', async () => {
+	test('SVG', async () => {
 		const markdown = new Markdown();
 		expect(
 			format(
 				await markdown.toHtml(
 					`
-@file1.jpg: image1
-@file2.svg: image2
-@file3.mp4: video1
+@file.svg: title<title> title
+`
+				)
+			)
+		).toBe(
+			`
+<figure>
+	<div class="p-embed"><img src="https://media.w0s.jp/image/blog/file.svg" alt="" class="p-embed__image" /></div>
+	<figcaption class="c-caption">title&lt;title> title</figcaption>
+</figure>
+`.trim()
+		);
+	});
+
+	test('MP4', async () => {
+		const markdown = new Markdown();
+		expect(
+			format(
+				await markdown.toHtml(
+					`
+@file.mp4: title<title> title
+`
+				)
+			)
+		).toBe(
+			`
+<figure>
+	<div class="p-embed"><video src="https://media.w0s.jp/video/blog/file.mp4" controls class="p-embed__video"></video></div>
+	<figcaption class="c-caption">title&lt;title> title</figcaption>
+</figure>
+`.trim()
+		);
+	});
+
+	test('invalid extension', async () => {
+		const markdown = new Markdown();
+		expect(
+			format(
+				await markdown.toHtml(
+					`
+@file.xxx: title<title> title
+`
+				)
+			)
+		).toBe(
+			`
+<figure>
+	<div class="p-embed"></div>
+	<figcaption class="c-caption">title&lt;title> title</figcaption>
+</figure>
+`.trim()
+		);
+	});
+
+	test('meta - last non Text', async () => {
+		const markdown = new Markdown();
+		expect(
+			format(
+				await markdown.toHtml(
+					`
+@file.jpg: title<title> \`code\`
 `
 				)
 			)
@@ -950,22 +1008,68 @@ describe('Image', () => {
 			`
 <figure>
 	<div class="p-embed">
-		<a href="https://media.w0s.jp/image/blog/file1.jpg"
+		<a href="https://media.w0s.jp/image/blog/file.jpg"
 			><picture
-				><source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/file1.jpg?type=avif;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file1.jpg?type=avif;w=1280;h=960;quality=30 2x" />
-				<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/file1.jpg?type=webp;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file1.jpg?type=webp;w=1280;h=960;quality=30 2x" />
-				<img src="https://media.w0s.jp/thumbimage/blog/file1.jpg?type=jpeg;w=640;h=480;quality=60" alt="オリジナル画像" class="p-embed__image" /></picture
+				><source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=1280;h=960;quality=30 2x" />
+				<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=1280;h=960;quality=30 2x" />
+				<img src="https://media.w0s.jp/thumbimage/blog/file.jpg?type=jpeg;w=640;h=480;quality=60" alt="オリジナル画像" class="p-embed__image" /></picture
 		></a>
 	</div>
-	<figcaption class="c-caption">image1</figcaption>
+	<figcaption class="c-caption">title&lt;title> <code>code</code></figcaption>
 </figure>
+`.trim()
+		);
+	});
+
+	test('meta - HTML', async () => {
+		const markdown = new Markdown();
+		expect(
+			format(
+				await markdown.toHtml(
+					`
+@file.jpg: title<title> title <meta>
+`
+				)
+			)
+		).toBe(
+			`
 <figure>
-	<div class="p-embed"><img src="https://media.w0s.jp/image/blog/file2.svg" alt="" class="p-embed__image" /></div>
-	<figcaption class="c-caption">image2</figcaption>
+	<div class="p-embed">
+		<a href="https://media.w0s.jp/image/blog/file.jpg"
+			><picture
+				><source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=1280;h=960;quality=30 2x" />
+				<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=1280;h=960;quality=30 2x" />
+				<img src="https://media.w0s.jp/thumbimage/blog/file.jpg?type=jpeg;w=640;h=480;quality=60" alt="オリジナル画像" class="p-embed__image" /></picture
+		></a>
+	</div>
+	<figcaption class="c-caption">title&lt;title> title</figcaption>
 </figure>
+`.trim()
+		);
+	});
+
+	test('meta - Text', async () => {
+		const markdown = new Markdown();
+		expect(
+			format(
+				await markdown.toHtml(
+					`
+@file.jpg: title<title> title <10 10>
+`
+				)
+			)
+		).toBe(
+			`
 <figure>
-	<div class="p-embed"><video src="https://media.w0s.jp/video/blog/file3.mp4" controls class="p-embed__video"></video></div>
-	<figcaption class="c-caption">video1</figcaption>
+	<div class="p-embed">
+		<a href="https://media.w0s.jp/image/blog/file.jpg"
+			><picture
+				><source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=1280;h=960;quality=30 2x" />
+				<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=1280;h=960;quality=30 2x" />
+				<img src="https://media.w0s.jp/thumbimage/blog/file.jpg?type=jpeg;w=640;h=480;quality=60" alt="オリジナル画像" class="p-embed__image" /></picture
+		></a>
+	</div>
+	<figcaption class="c-caption">title&lt;title> title</figcaption>
 </figure>
 `.trim()
 		);
@@ -984,142 +1088,6 @@ describe('Image', () => {
 		).toBe(
 			`
 <p>@file.jpg title</p>
-`.trim()
-		);
-	});
-
-	test('row2 invalid', async () => {
-		const markdown = new Markdown();
-		expect(
-			format(
-				await markdown.toHtml(
-					`
-@file.jpg: title
-file.jpg
-`
-				)
-			)
-		).toBe(
-			`
-<p>@file.jpg: title file.jpg</p>
-`.trim()
-		);
-	});
-});
-
-describe('Amazon', () => {
-	test('normal', async () => {
-		const markdown = new Markdown();
-		expect(
-			format(
-				await markdown.toHtml(
-					`
-@amazon: 1234567890 title<title> title
-`
-				)
-			)
-		).toBe(
-			`
-<aside class="p-amazon">
-	<h2 class="p-amazon__hdg"><img src="/image/entry/amazon-buy.png" srcset="/image/entry/amazon-buy@2x.png 2x" alt="Amazon で買う" width="127" height="26" /></h2>
-	<ul class="p-amazon__list">
-		<li>
-			<a class="p-amazon__link" href="https://www.amazon.co.jp/dp/1234567890/ref=nosim?tag=w0s.jp-22"
-				><div class="p-amazon__thumb"><img src="/image/entry/amazon-noimage.svg" alt="" width="113" height="160" class="p-amazon__image" /></div>
-				<div class="p-amazon__text"><p class="p-amazon__title">title&lt;title> title</p></div></a
-			>
-		</li>
-	</ul>
-</aside>
-`.trim()
-		);
-	});
-
-	test('image', async () => {
-		const markdown = new Markdown();
-		expect(
-			format(
-				await markdown.toHtml(
-					`
-@amazon: 1234567890 title<title> title <abcdef>
-`
-				)
-			)
-		).toBe(
-			`
-<aside class="p-amazon">
-	<h2 class="p-amazon__hdg"><img src="/image/entry/amazon-buy.png" srcset="/image/entry/amazon-buy@2x.png 2x" alt="Amazon で買う" width="127" height="26" /></h2>
-	<ul class="p-amazon__list">
-		<li>
-			<a class="p-amazon__link" href="https://www.amazon.co.jp/dp/1234567890/ref=nosim?tag=w0s.jp-22"
-				><div class="p-amazon__thumb"><img src="https://m.media-amazon.com/images/I/abcdef._SL160_.jpg" srcset="https://m.media-amazon.com/images/I/abcdef._SL320_.jpg 2x" alt="" class="p-amazon__image" /></div>
-				<div class="p-amazon__text"><p class="p-amazon__title">title&lt;title> title</p></div></a
-			>
-		</li>
-	</ul>
-</aside>
-`.trim()
-		);
-	});
-
-	test('image size', async () => {
-		const markdown = new Markdown();
-		expect(
-			format(
-				await markdown.toHtml(
-					`
-@amazon: 1234567890 title <abcdef 99x150>
-`
-				)
-			)
-		).toBe(
-			`
-<aside class="p-amazon">
-	<h2 class="p-amazon__hdg"><img src="/image/entry/amazon-buy.png" srcset="/image/entry/amazon-buy@2x.png 2x" alt="Amazon で買う" width="127" height="26" /></h2>
-	<ul class="p-amazon__list">
-		<li>
-			<a class="p-amazon__link" href="https://www.amazon.co.jp/dp/1234567890/ref=nosim?tag=w0s.jp-22"
-				><div class="p-amazon__thumb"><img src="https://m.media-amazon.com/images/I/abcdef._SL160_.jpg" srcset="https://m.media-amazon.com/images/I/abcdef._SL320_.jpg 2x" alt="" width="106" height="160" class="p-amazon__image" /></div>
-				<div class="p-amazon__text"><p class="p-amazon__title">title</p></div></a
-			>
-		</li>
-	</ul>
-</aside>
-`.trim()
-		);
-	});
-
-	test('asin invalid', async () => {
-		const markdown = new Markdown();
-		expect(
-			format(
-				await markdown.toHtml(
-					`
-@amazon: 1234 title
-`
-				)
-			)
-		).toBe(
-			`
-<p>@amazon: 1234 title</p>
-`.trim()
-		);
-	});
-
-	test('multi invalid', async () => {
-		const markdown = new Markdown();
-		expect(
-			format(
-				await markdown.toHtml(
-					`
-@amazon: 1234567890 title
-@youtube: 1234567890 title
-`
-				)
-			)
-		).toBe(
-			`
-<p>@amazon: 1234567890 title @youtube: 1234567890 title</p>
 `.trim()
 		);
 	});
@@ -1219,6 +1187,156 @@ describe('YouTube', () => {
 		).toBe(
 			`
 <p>@youtube: aaa@</p>
+`.trim()
+		);
+	});
+});
+
+describe('Amazon', () => {
+	test('normal', async () => {
+		const markdown = new Markdown();
+		expect(
+			format(
+				await markdown.toHtml(
+					`
+- @amazon: 1234567890 title<title> title
+`
+				)
+			)
+		).toBe(
+			`
+<aside class="p-amazon">
+	<h2 class="p-amazon__hdg"><img src="/image/entry/amazon-buy.png" srcset="/image/entry/amazon-buy@2x.png 2x" alt="Amazon で買う" width="127" height="26" /></h2>
+	<ul class="p-amazon__list">
+		<li>
+			<a class="p-amazon__link" href="https://www.amazon.co.jp/dp/1234567890/ref=nosim?tag=w0s.jp-22"
+				><div class="p-amazon__thumb"><img src="/image/entry/amazon-noimage.svg" alt="" width="113" height="160" class="p-amazon__image" /></div>
+				<div class="p-amazon__text"><p class="p-amazon__title">title&lt;title> title</p></div></a
+			>
+		</li>
+	</ul>
+</aside>
+`.trim()
+		);
+	});
+
+	test('image', async () => {
+		const markdown = new Markdown();
+		expect(
+			format(
+				await markdown.toHtml(
+					`
+- @amazon: 1234567890 title<title> title <abcdef>
+`
+				)
+			)
+		).toBe(
+			`
+<aside class="p-amazon">
+	<h2 class="p-amazon__hdg"><img src="/image/entry/amazon-buy.png" srcset="/image/entry/amazon-buy@2x.png 2x" alt="Amazon で買う" width="127" height="26" /></h2>
+	<ul class="p-amazon__list">
+		<li>
+			<a class="p-amazon__link" href="https://www.amazon.co.jp/dp/1234567890/ref=nosim?tag=w0s.jp-22"
+				><div class="p-amazon__thumb"><img src="https://m.media-amazon.com/images/I/abcdef._SL160_.jpg" srcset="https://m.media-amazon.com/images/I/abcdef._SL320_.jpg 2x" alt="" class="p-amazon__image" /></div>
+				<div class="p-amazon__text"><p class="p-amazon__title">title&lt;title> title</p></div></a
+			>
+		</li>
+	</ul>
+</aside>
+`.trim()
+		);
+	});
+
+	test('image size (width > height)', async () => {
+		const markdown = new Markdown();
+		expect(
+			format(
+				await markdown.toHtml(
+					`
+- @amazon: 1234567890 title <abcdef 150x99>
+`
+				)
+			)
+		).toBe(
+			`
+<aside class="p-amazon">
+	<h2 class="p-amazon__hdg"><img src="/image/entry/amazon-buy.png" srcset="/image/entry/amazon-buy@2x.png 2x" alt="Amazon で買う" width="127" height="26" /></h2>
+	<ul class="p-amazon__list">
+		<li>
+			<a class="p-amazon__link" href="https://www.amazon.co.jp/dp/1234567890/ref=nosim?tag=w0s.jp-22"
+				><div class="p-amazon__thumb"><img src="https://m.media-amazon.com/images/I/abcdef._SL160_.jpg" srcset="https://m.media-amazon.com/images/I/abcdef._SL320_.jpg 2x" alt="" width="160" height="106" class="p-amazon__image" /></div>
+				<div class="p-amazon__text"><p class="p-amazon__title">title</p></div></a
+			>
+		</li>
+	</ul>
+</aside>
+`.trim()
+		);
+	});
+
+	test('image size (width < height)', async () => {
+		const markdown = new Markdown();
+		expect(
+			format(
+				await markdown.toHtml(
+					`
+- @amazon: 1234567890 title <abcdef 99x150>
+`
+				)
+			)
+		).toBe(
+			`
+<aside class="p-amazon">
+	<h2 class="p-amazon__hdg"><img src="/image/entry/amazon-buy.png" srcset="/image/entry/amazon-buy@2x.png 2x" alt="Amazon で買う" width="127" height="26" /></h2>
+	<ul class="p-amazon__list">
+		<li>
+			<a class="p-amazon__link" href="https://www.amazon.co.jp/dp/1234567890/ref=nosim?tag=w0s.jp-22"
+				><div class="p-amazon__thumb"><img src="https://m.media-amazon.com/images/I/abcdef._SL160_.jpg" srcset="https://m.media-amazon.com/images/I/abcdef._SL320_.jpg 2x" alt="" width="106" height="160" class="p-amazon__image" /></div>
+				<div class="p-amazon__text"><p class="p-amazon__title">title</p></div></a
+			>
+		</li>
+	</ul>
+</aside>
+`.trim()
+		);
+	});
+
+	test('asin invalid', async () => {
+		const markdown = new Markdown();
+		expect(
+			format(
+				await markdown.toHtml(
+					`
+- @amazon: 1234 title
+`
+				)
+			)
+		).toBe(
+			`
+<ul class="p-list">
+	<li>@amazon: 1234 title</li>
+</ul>
+`.trim()
+		);
+	});
+
+	test('multi invalid', async () => {
+		const markdown = new Markdown();
+		expect(
+			format(
+				await markdown.toHtml(
+					`
+- @amazon: 1234567890 title
+- @youtube: 1234567890 title
+`
+				)
+			)
+		).toBe(
+			`
+<ul class="p-list">
+	<li>@amazon: 1234567890 title</li>
+	<li>@youtube: 1234567890 title</li>
+</ul>
 `.trim()
 		);
 	});

--- a/packages/frontend/script/admin.ts
+++ b/packages/frontend/script/admin.ts
@@ -49,27 +49,22 @@ const messageCtrlElement = <HTMLTextAreaElement | null>document.getElementById('
 const markdownMessagesElement = <HTMLTemplateElement | null>document.getElementById('markdown-messages'); // Markdown 変換結果のメッセージを表示する要素
 const messagePreviewElement = <HTMLTemplateElement | null>document.getElementById('message-preview'); // 本文プレビューを表示する要素
 const selectImageElement = <HTMLTemplateElement | null>document.getElementById('select-image');
-const selectImageErrorElement = <HTMLTemplateElement | null>document.getElementById('select-image-error');
-if (
-	messageCtrlElement !== null &&
-	markdownMessagesElement !== null &&
-	messagePreviewElement !== null &&
-	selectImageElement !== null &&
-	selectImageErrorElement !== null
-) {
+
+if (messageCtrlElement !== null && markdownMessagesElement !== null && messagePreviewElement !== null && selectImageElement !== null) {
 	const preview = new Preview({
 		ctrl: messageCtrlElement,
 		messages: markdownMessagesElement,
 		preview: messagePreviewElement,
 	});
+
 	const messageImage = new MessageImage({
-		ctrl: messageCtrlElement,
+		preview: messagePreviewElement,
 		image: selectImageElement,
-		error: selectImageErrorElement,
 	});
 
 	const exec = async (): Promise<void> => {
-		await Promise.all([preview.exec(), messageImage.exec()]);
+		await preview.exec();
+		await messageImage.exec();
 	};
 
 	exec();

--- a/packages/frontend/script/unique/MessageImage.ts
+++ b/packages/frontend/script/unique/MessageImage.ts
@@ -1,20 +1,17 @@
 import PaapiItemImageUrlParser from '@saekitominaga/paapi-item-image-url-parser';
 
 interface Option {
-	ctrl: HTMLTextAreaElement;
+	preview: HTMLTemplateElement;
 	image: HTMLTemplateElement;
-	error: HTMLTemplateElement;
 }
 
 /**
  * 記事を解析して画像情報を抜粋する
  */
 export default class MessageImage {
-	readonly #ctrlElement: HTMLTextAreaElement; // 本文入力欄
+	readonly #previewElement: HTMLTemplateElement; // 本文プレビューを表示する要素
 
 	readonly #selectImageElement: HTMLTemplateElement; // 選択画像を表示する要素
-
-	readonly #selectImageErrorElement: HTMLTemplateElement; // エラー情報を表示する要素
 
 	readonly #imageName: string | undefined; // 既存記事でもともと指定されていた画像（ファイル名 or 外部サービス URL）
 
@@ -22,9 +19,8 @@ export default class MessageImage {
 	 * @param options - Option
 	 */
 	constructor(options: Option) {
-		this.#ctrlElement = options.ctrl;
+		this.#previewElement = options.preview;
 		this.#selectImageElement = options.image;
-		this.#selectImageErrorElement = options.error;
 
 		this.#imageName = options.image.dataset['selected'];
 	}
@@ -43,89 +39,28 @@ export default class MessageImage {
 			}
 			this.#selectImageElement.nextElementSibling.remove();
 		}
-		while (this.#selectImageErrorElement.nextElementSibling) {
-			this.#selectImageErrorElement.nextElementSibling.remove();
-		}
-
-		const imageNames: Set<string> = new Set(); // 画像ファイル名 or 外部サービス URL
-		const errorMessages: Set<string> = new Set(); // エラーメッセージ
-
-		const youtubeIds: Set<string> = new Set(); // YouTube ID
-		const amazonImageIds: Set<string> = new Set(); // Amazon 画像 ID
 
 		/* 本文内のテキストから画像パスと ASIN を抜き出す */
-		this.#ctrlElement.value.split('\n').forEach((line: string): void => {
-			const EMBEDDED_START = '@';
-			const SERVICE_AMAZON = 'amazon';
-			const SERVICE_YOUTUBE = 'youtube';
-			const NAME_META_SEPARATOR = ': ';
-			const META_SEPARATOR = ' ';
-			const OPTION_OPEN = ' <';
-			const OPTION_CLOSE = '>';
+		const preview = this.#previewElement.nextElementSibling;
+		if (preview === null) {
+			return;
+		}
 
-			if (!line.startsWith(EMBEDDED_START)) {
-				return;
-			}
-
-			const nameMetaSeparatorIndex = line.indexOf(NAME_META_SEPARATOR);
-			if (nameMetaSeparatorIndex === -1) {
-				return;
-			}
-
-			const name = line.substring(EMBEDDED_START.length, nameMetaSeparatorIndex);
-			const meta = line.substring(nameMetaSeparatorIndex + NAME_META_SEPARATOR.length);
-
-			const optionOpenIndex = meta.lastIndexOf(OPTION_OPEN);
-			const optionCloseIndex = meta.lastIndexOf(OPTION_CLOSE);
-
-			let require = meta;
-			let option: string | undefined;
-			if (optionOpenIndex !== -1 && optionCloseIndex === meta.length - OPTION_CLOSE.length) {
-				require = meta.substring(0, optionOpenIndex);
-				option = meta.substring(optionOpenIndex + OPTION_OPEN.length, meta.length - OPTION_CLOSE.length);
-			}
-
-			if (name.includes('.')) {
-				imageNames.add(name);
-			} else {
-				switch (name) {
-					case SERVICE_AMAZON: {
-						option?.split(META_SEPARATOR).forEach((fragment) => {
-							if (!/^[1-9][0-9]{1,2}x[1-9][0-9]{1,2}$/.test(fragment) && /^[a-zA-Z0-9-_+%]+$/.test(fragment)) {
-								/* 画像ID */
-								amazonImageIds.add(fragment);
-							}
-						});
-						break;
-					}
-					case SERVICE_YOUTUBE: {
-						const requireSeparator1Index = require.indexOf(META_SEPARATOR);
-						const id = require.substring(0, requireSeparator1Index);
-
-						youtubeIds.add(id);
-						break;
-					}
-					default:
-				}
-			}
+		const imageFileNames = [...preview.querySelectorAll<HTMLAnchorElement>('.p-embed > a[href^="https://media.w0s.jp/image/blog/"]')].map((element) =>
+			element.href.substring('https://media.w0s.jp/image/blog/'.length)
+		);
+		const youtubeImageUrls = [...preview.querySelectorAll<HTMLAnchorElement>('.c-caption > a[href^="https://www.youtube.com/watch?v="]')].map(
+			(element) => `https://i1.ytimg.com/vi/${new URL(element.href).searchParams.get('v')}/hqdefault.jpg`
+		);
+		const amazonImageUrls = [...preview.querySelectorAll<HTMLImageElement>('img.p-amazon__image')].map((element) => {
+			const paapiItemImageUrlParser = new PaapiItemImageUrlParser(new URL(element.src));
+			paapiItemImageUrlParser.removeSize();
+			return paapiItemImageUrlParser.toString();
 		});
 
-		/* YouTube */
-		for (const youtubeId of youtubeIds) {
-			imageNames.add(`https://i1.ytimg.com/vi/${youtubeId}/hqdefault.jpg`);
-		}
+		const images: Set<string> = new Set([...imageFileNames, ...youtubeImageUrls, ...amazonImageUrls]);
 
-		/* Amazon */
-		if (amazonImageIds.size >= 1) {
-			amazonImageIds.forEach((imageId) => {
-				const paapiItemImageUrlParser = new PaapiItemImageUrlParser(new URL(`https://m.media-amazon.com/images/I/${imageId}.jpg`));
-				paapiItemImageUrlParser.removeSize();
-				imageNames.add(paapiItemImageUrlParser.toString());
-			});
-		}
-
-		this.#displayRadioButtons(imageNames, selectedImageName);
-		this.#displayErrorMessages(errorMessages);
+		this.#displayRadioButtons(images, selectedImageName);
 	}
 
 	/**
@@ -161,23 +96,5 @@ export default class MessageImage {
 			fragment.appendChild(templateElementClone);
 		}
 		this.#selectImageElement.parentNode?.appendChild(fragment);
-	}
-
-	/**
-	 * エラーメッセージを表示する
-	 *
-	 * @param messages - エラーメッセージ
-	 */
-	#displayErrorMessages(messages: Set<string>): void {
-		const fragment = document.createDocumentFragment();
-		for (const message of messages) {
-			const templateElementClone = this.#selectImageErrorElement.content.cloneNode(true) as HTMLElement;
-
-			const liElement = <HTMLLIElement>templateElementClone.querySelector('li');
-			liElement.textContent = message;
-
-			fragment.appendChild(templateElementClone);
-		}
-		this.#selectImageErrorElement.parentNode?.appendChild(fragment);
 	}
 }

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -164,13 +164,6 @@
 													</li>
 												</template>
 											</ul>
-											<div class="c-form-controls">
-												<ul class="p-list">
-													<template id="select-image-error">
-														<li></li>
-													</template>
-												</ul>
-											</div>
 										</div>
 									</fieldset>
 								</div>

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -373,7 +373,7 @@
 									<td>YouTube 動画</td>
 								</tr>
 								<tr>
-									<th scope="row">@amazon:<b class="u-red">␣</b>ASIN<b class="u-red">␣</b>商品タイトル<b class="u-red">␣</b>&lt;画像ID<b class="u-red">?</b><b class="u-red">␣</b>幅x高さ<b class="u-red">?</b>&gt;</th>
+									<th scope="row">- @amazon:<b class="u-red">␣</b>ASIN<b class="u-red">␣</b>商品タイトル<b class="u-red">␣</b>&lt;画像ID<b class="u-red">?</b><b class="u-red">␣</b>幅x高さ<b class="u-red">?</b>&gt;</th>
 									<td>Amazon 商品</td>
 								</tr>
 								<tr>


### PR DESCRIPTION
fix #315

- 画像キャプション部分の Markdown を認識するようにした
- YouTube 動画はキャプション内にリンクを張ることもあり、引き続きあえて無視する
- Amazon 商品もタイトル部分にリンクを張ることもあり、引き続きあえて無視する
- 複数行の構文を取り止め。Amazon 商品は逆にリスト（`- `）構文内への記載を必須とする。