### PR TITLE
記事投稿時の Mastodon トゥート機能を追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1947,6 +1947,18 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/@mastojs/ponyfills": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@mastojs/ponyfills/-/ponyfills-1.0.4.tgz",
+			"integrity": "sha512-1NaIGmcU7OmyNzx0fk+cYeGTkdXlOJOSdetaC4pStVWsrhht2cdlYSAfe5NDW3FcUmcEm2vVceB9lcClN1RCxw==",
+			"dependencies": {
+				"@types/node": "^18.11.17",
+				"@types/node-fetch": "^2.6.2",
+				"abort-controller": "^3.0.0",
+				"form-data": "^4.0.0",
+				"node-fetch": "^2.6.7"
+			}
+		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2567,8 +2579,29 @@
 		"node_modules/@types/node": {
 			"version": "18.11.17",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-			"integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
-			"dev": true
+			"integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
+		},
+		"node_modules/@types/node-fetch": {
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
+			"integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+			"dependencies": {
+				"@types/node": "*",
+				"form-data": "^3.0.0"
+			}
+		},
+		"node_modules/@types/node-fetch/node_modules/form-data": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+			"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/@types/nodemailer": {
 			"version": "6.4.8",
@@ -2976,6 +3009,17 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
@@ -3978,6 +4022,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/camel-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+			"dependencies": {
+				"pascal-case": "^3.1.2",
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -4032,6 +4085,16 @@
 				}
 			]
 		},
+		"node_modules/capital-case": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
+			}
+		},
 		"node_modules/ccount": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -4054,6 +4117,25 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/change-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+			"dependencies": {
+				"camel-case": "^4.1.2",
+				"capital-case": "^1.0.4",
+				"constant-case": "^3.0.4",
+				"dot-case": "^3.0.4",
+				"header-case": "^2.0.4",
+				"no-case": "^3.0.4",
+				"param-case": "^3.0.4",
+				"pascal-case": "^3.1.2",
+				"path-case": "^3.0.4",
+				"sentence-case": "^3.0.4",
+				"snake-case": "^3.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/char-regex": {
@@ -4459,6 +4541,16 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
+		},
+		"node_modules/constant-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case": "^2.0.2"
+			}
 		},
 		"node_modules/content-disposition": {
 			"version": "0.5.4",
@@ -4880,9 +4972,9 @@
 			}
 		},
 		"node_modules/dayjs": {
-			"version": "1.11.7",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-			"integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+			"version": "1.11.9",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
+			"integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA=="
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
@@ -5221,6 +5313,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
+		"node_modules/dot-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/dot-prop": {
@@ -5945,6 +6046,19 @@
 				"d": "1",
 				"es5-ext": "~0.10.14"
 			}
+		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/eventemitter3": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
 		},
 		"node_modules/execa": {
 			"version": "5.1.1",
@@ -7171,6 +7285,15 @@
 				"url": "https://opencollective.com/unified"
 			}
 		},
+		"node_modules/header-case": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+			"dependencies": {
+				"capital-case": "^1.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/highlight.js": {
 			"version": "11.8.0",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
@@ -7981,6 +8104,14 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"devOptional": true
+		},
+		"node_modules/isomorphic-ws": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+			"integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+			"peerDependencies": {
+				"ws": "*"
+			}
 		},
 		"node_modules/istanbul-lib-coverage": {
 			"version": "3.2.0",
@@ -9249,6 +9380,14 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
+		"node_modules/lower-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -9466,6 +9605,20 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/masto": {
+			"version": "5.11.3",
+			"resolved": "https://registry.npmjs.org/masto/-/masto-5.11.3.tgz",
+			"integrity": "sha512-GtSnrqm5fHPaaU0iwag4LCmvpp82rDng6yOZinmOJHHlUfo6Gnq5QY6x3lJCxCnsPIXpTu1yaX42bWrSQyoQPA==",
+			"dependencies": {
+				"@mastojs/ponyfills": "^1.0.4",
+				"change-case": "^4.1.2",
+				"eventemitter3": "^5.0.0",
+				"isomorphic-ws": "^5.0.0",
+				"qs": "^6.11.0",
+				"semver": "^7.3.7",
+				"ws": "^8.13.0"
 			}
 		},
 		"node_modules/mathml-tag-names": {
@@ -10599,6 +10752,15 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
+		"node_modules/no-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+			"dependencies": {
+				"lower-case": "^2.0.2",
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/node-addon-api": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
@@ -11458,6 +11620,15 @@
 				"semver": "bin/semver.js"
 			}
 		},
+		"node_modules/param-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+			"dependencies": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -11514,6 +11685,24 @@
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/pascal-case": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/path-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+			"dependencies": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/path-exists": {
@@ -13733,6 +13922,16 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
+		"node_modules/sentence-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+			"dependencies": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
+			}
+		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
@@ -13889,6 +14088,15 @@
 			"resolved": "https://registry.npmjs.org/smob/-/smob-1.4.0.tgz",
 			"integrity": "sha512-MqR3fVulhjWuRNSMydnTlweu38UhQ0HXM4buStD/S3mc/BzX3CuM9OmhyQpmtYCvoYdl5ris6TI0ZqH355Ymqg==",
 			"dev": true
+		},
+		"node_modules/snake-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+			"dependencies": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
 		},
 		"node_modules/socks": {
 			"version": "2.7.1",
@@ -14983,8 +15191,7 @@
 		"node_modules/tslib": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"dev": true
+			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
@@ -15445,6 +15652,22 @@
 			"dev": true,
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/upper-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+			"dependencies": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"node_modules/upper-case-first": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+			"dependencies": {
+				"tslib": "^2.0.3"
 			}
 		},
 		"node_modules/uri-js": {
@@ -16109,6 +16332,7 @@
 				"jsdom": "^22.1.0",
 				"kill-port": "^2.0.1",
 				"log4js": "^6.9.1",
+				"masto": "^5.11.3",
 				"md5": "^2.3.0",
 				"mdast-util-definition-list": "^1.4.0",
 				"mdast-util-gfm-footnote": "^1.0.2",
@@ -16763,6 +16987,7 @@
 				"jsdom": "^22.1.0",
 				"kill-port": "^2.0.1",
 				"log4js": "^6.9.1",
+				"masto": "^5.11.3",
 				"md5": "^2.3.0",
 				"mdast-util-definition-list": "^1.4.0",
 				"mdast-util-gfm-footnote": "^1.0.2",
@@ -17815,6 +18040,18 @@
 				}
 			}
 		},
+		"@mastojs/ponyfills": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@mastojs/ponyfills/-/ponyfills-1.0.4.tgz",
+			"integrity": "sha512-1NaIGmcU7OmyNzx0fk+cYeGTkdXlOJOSdetaC4pStVWsrhht2cdlYSAfe5NDW3FcUmcEm2vVceB9lcClN1RCxw==",
+			"requires": {
+				"@types/node": "^18.11.17",
+				"@types/node-fetch": "^2.6.2",
+				"abort-controller": "^3.0.0",
+				"form-data": "^4.0.0",
+				"node-fetch": "^2.6.7"
+			}
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -18358,8 +18595,28 @@
 		"@types/node": {
 			"version": "18.11.17",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.17.tgz",
-			"integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng==",
-			"dev": true
+			"integrity": "sha512-HJSUJmni4BeDHhfzn6nF0sVmd1SMezP7/4F0Lq+aXzmp2xm9O7WXrUtHW/CHlYVtZUbByEvWidHqRtcJXGF2Ng=="
+		},
+		"@types/node-fetch": {
+			"version": "2.6.4",
+			"resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.4.tgz",
+			"integrity": "sha512-1ZX9fcN4Rvkvgv4E6PAY5WXUFWFcRWxZa3EW83UjycOB9ljJCedb2CupIP4RZMEwF/M3eTcCihbBRgwtGbg5Rg==",
+			"requires": {
+				"@types/node": "*",
+				"form-data": "^3.0.0"
+			},
+			"dependencies": {
+				"form-data": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+					"integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+					"requires": {
+						"asynckit": "^0.4.0",
+						"combined-stream": "^1.0.8",
+						"mime-types": "^2.1.12"
+					}
+				}
+			}
 		},
 		"@types/nodemailer": {
 			"version": "6.4.8",
@@ -18665,6 +18922,14 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
 			"integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
+		},
+		"abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"requires": {
+				"event-target-shim": "^5.0.0"
+			}
 		},
 		"accepts": {
 			"version": "1.3.8",
@@ -19406,6 +19671,15 @@
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true
 		},
+		"camel-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/camel-case/-/camel-case-4.1.2.tgz",
+			"integrity": "sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==",
+			"requires": {
+				"pascal-case": "^3.1.2",
+				"tslib": "^2.0.3"
+			}
+		},
 		"camelcase": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -19441,6 +19715,16 @@
 			"integrity": "sha512-1MgUzEkoMO6gKfXflStpYgZDlFM7M/ck/bgfVCACO5vnAf0fXoNVHdWtqGU+MYca+4bL9Z5bpOVmR33cWW9G2A==",
 			"dev": true
 		},
+		"capital-case": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/capital-case/-/capital-case-1.0.4.tgz",
+			"integrity": "sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==",
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
+			}
+		},
 		"ccount": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
@@ -19453,6 +19737,25 @@
 			"requires": {
 				"ansi-styles": "^4.1.0",
 				"supports-color": "^7.1.0"
+			}
+		},
+		"change-case": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/change-case/-/change-case-4.1.2.tgz",
+			"integrity": "sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==",
+			"requires": {
+				"camel-case": "^4.1.2",
+				"capital-case": "^1.0.4",
+				"constant-case": "^3.0.4",
+				"dot-case": "^3.0.4",
+				"header-case": "^2.0.4",
+				"no-case": "^3.0.4",
+				"param-case": "^3.0.4",
+				"pascal-case": "^3.1.2",
+				"path-case": "^3.0.4",
+				"sentence-case": "^3.0.4",
+				"snake-case": "^3.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"char-regex": {
@@ -19767,6 +20070,16 @@
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
 			"integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
 		},
+		"constant-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
+			"integrity": "sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==",
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case": "^2.0.2"
+			}
+		},
 		"content-disposition": {
 			"version": "0.5.4",
 			"resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
@@ -20061,9 +20374,9 @@
 			"integrity": "sha512-39BOQLs9ZjKh0/patS9nrT8wc3ioX3/eA/zgbKNopnF2wCqJEoxywwwElATYvRsXdnOxA/OQeQoFZ3rFjVajhg=="
 		},
 		"dayjs": {
-			"version": "1.11.7",
-			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.7.tgz",
-			"integrity": "sha512-+Yw9U6YO5TQohxLcIkrXBeY73WP3ejHWVvx8XCk3gxvQDCTEmS48ZrSZCKciI7Bhl/uCMyxYtE9UqRILmFphkQ=="
+			"version": "1.11.9",
+			"resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.9.tgz",
+			"integrity": "sha512-QvzAURSbQ0pKdIye2txOzNaHmxtUBXerpY0FJsFXUMKbIZeFm5ht1LS/jFsrncjnmtv8HsG0W2g6c0zUjZWmpA=="
 		},
 		"debug": {
 			"version": "4.3.4",
@@ -20296,6 +20609,15 @@
 				"dom-serializer": "^2.0.0",
 				"domelementtype": "^2.3.0",
 				"domhandler": "^5.0.1"
+			}
+		},
+		"dot-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/dot-case/-/dot-case-3.0.4.tgz",
+			"integrity": "sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==",
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
 			}
 		},
 		"dot-prop": {
@@ -20874,6 +21196,16 @@
 				"d": "1",
 				"es5-ext": "~0.10.14"
 			}
+		},
+		"event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+		},
+		"eventemitter3": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="
 		},
 		"execa": {
 			"version": "5.1.1",
@@ -21819,6 +22151,15 @@
 				"space-separated-tokens": "^2.0.0"
 			}
 		},
+		"header-case": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/header-case/-/header-case-2.0.4.tgz",
+			"integrity": "sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==",
+			"requires": {
+				"capital-case": "^1.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
 		"highlight.js": {
 			"version": "11.8.0",
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
@@ -22389,6 +22730,12 @@
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
 			"devOptional": true
+		},
+		"isomorphic-ws": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+			"integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+			"requires": {}
 		},
 		"istanbul-lib-coverage": {
 			"version": "3.2.0",
@@ -23364,6 +23711,14 @@
 			"resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
 			"integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
 		},
+		"lower-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
+			"integrity": "sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==",
+			"requires": {
+				"tslib": "^2.0.3"
+			}
+		},
 		"lowercase-keys": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
@@ -23537,6 +23892,20 @@
 					"integrity": "sha512-qj9wWsnFvVEMUDbESiilKeXeHL7FwwiFcogfhfyjmvT968RXSvnl23f1JOClTHYItsi7o501C/7qVllscUP3oA==",
 					"dev": true
 				}
+			}
+		},
+		"masto": {
+			"version": "5.11.3",
+			"resolved": "https://registry.npmjs.org/masto/-/masto-5.11.3.tgz",
+			"integrity": "sha512-GtSnrqm5fHPaaU0iwag4LCmvpp82rDng6yOZinmOJHHlUfo6Gnq5QY6x3lJCxCnsPIXpTu1yaX42bWrSQyoQPA==",
+			"requires": {
+				"@mastojs/ponyfills": "^1.0.4",
+				"change-case": "^4.1.2",
+				"eventemitter3": "^5.0.0",
+				"isomorphic-ws": "^5.0.0",
+				"qs": "^6.11.0",
+				"semver": "^7.3.7",
+				"ws": "^8.13.0"
 			}
 		},
 		"mathml-tag-names": {
@@ -24289,6 +24658,15 @@
 			"integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
 			"dev": true
 		},
+		"no-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/no-case/-/no-case-3.0.4.tgz",
+			"integrity": "sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==",
+			"requires": {
+				"lower-case": "^2.0.2",
+				"tslib": "^2.0.3"
+			}
+		},
 		"node-addon-api": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
@@ -24921,6 +25299,15 @@
 				}
 			}
 		},
+		"param-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/param-case/-/param-case-3.0.4.tgz",
+			"integrity": "sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==",
+			"requires": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
 		"parent-module": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -24960,6 +25347,24 @@
 			"version": "1.3.3",
 			"resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
 			"integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
+		},
+		"pascal-case": {
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-3.1.2.tgz",
+			"integrity": "sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==",
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
+		},
+		"path-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/path-case/-/path-case-3.0.4.tgz",
+			"integrity": "sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==",
+			"requires": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
 		},
 		"path-exists": {
 			"version": "4.0.0",
@@ -26525,6 +26930,16 @@
 				}
 			}
 		},
+		"sentence-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-3.0.4.tgz",
+			"integrity": "sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==",
+			"requires": {
+				"no-case": "^3.0.4",
+				"tslib": "^2.0.3",
+				"upper-case-first": "^2.0.2"
+			}
+		},
 		"serialize-javascript": {
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.1.tgz",
@@ -26646,6 +27061,15 @@
 			"resolved": "https://registry.npmjs.org/smob/-/smob-1.4.0.tgz",
 			"integrity": "sha512-MqR3fVulhjWuRNSMydnTlweu38UhQ0HXM4buStD/S3mc/BzX3CuM9OmhyQpmtYCvoYdl5ris6TI0ZqH355Ymqg==",
 			"dev": true
+		},
+		"snake-case": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/snake-case/-/snake-case-3.0.4.tgz",
+			"integrity": "sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==",
+			"requires": {
+				"dot-case": "^3.0.4",
+				"tslib": "^2.0.3"
+			}
 		},
 		"socks": {
 			"version": "2.7.1",
@@ -27472,8 +27896,7 @@
 		"tslib": {
 			"version": "2.5.3",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-			"dev": true
+			"integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w=="
 		},
 		"tsutils": {
 			"version": "3.21.0",
@@ -27793,6 +28216,22 @@
 					"integrity": "sha512-m7ZEHgtw69qOGw+jwxXkHlrlIPdTGkyh66zXZ1ajZbxkDBNjSY/LGbmjc7h0s2ELsUDTAhFr55TrPSSqJGPG0A==",
 					"dev": true
 				}
+			}
+		},
+		"upper-case": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case/-/upper-case-2.0.2.tgz",
+			"integrity": "sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==",
+			"requires": {
+				"tslib": "^2.0.3"
+			}
+		},
+		"upper-case-first": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-2.0.2.tgz",
+			"integrity": "sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==",
+			"requires": {
+				"tslib": "^2.0.3"
 			}
 		},
 		"uri-js": {

--- a/packages/backend/configure/schema/common.json
+++ b/packages/backend/configure/schema/common.json
@@ -5,6 +5,7 @@
 	"title": "富永日記帳",
 	"required": [
 		"port",
+		"origin",
 		"request",
 		"response",
 		"static",
@@ -24,6 +25,10 @@
 			"minimum": 1,
 			"maximum": 65535,
 			"title": "HTTP サーバーのポート番号"
+		},
+		"origin": {
+			"type": "string",
+			"title": "オリジン"
 		},
 		"request": {
 			"type": "object",

--- a/packages/backend/configure/schema/post.json
+++ b/packages/backend/configure/schema/post.json
@@ -3,7 +3,7 @@
 	"$id": "https://blog.w0s.jp/post.json",
 	"type": "object",
 	"title": "記事投稿",
-	"required": ["view", "validator", "insert", "update", "update_modified", "feed_create", "sitemap_create", "newly_json_create", "media_upload"],
+	"required": ["view", "validator", "insert", "update", "update_modified", "feed_create", "sitemap_create", "newly_json_create", "social", "media_upload"],
 	"properties": {
 		"view": {
 			"type": "object",
@@ -209,6 +209,82 @@
 						"message_failure": {
 							"type": "string",
 							"title": "失敗時のメッセージ"
+						}
+					},
+					"additionalProperties": false
+				}
+			},
+			"additionalProperties": false
+		},
+		"social": {
+			"type": "object",
+			"title": "ソーシャルサービス投稿",
+			"required": ["mastodon"],
+			"properties": {
+				"mastodon": {
+					"type": "object",
+					"title": "Mastodon",
+					"required": ["api", "message_prefix", "url_prefix", "api_response"],
+					"properties": {
+						"api": {
+							"type": "object",
+							"title": "API 情報",
+							"required": ["development", "production"],
+							"properties": {
+								"development": {
+									"type": "object",
+									"title": "開発用",
+									"$ref": "#/properties/social/properties/mastodon/properties/api/definitions/api"
+								},
+								"production": {
+									"type": "object",
+									"title": "本番用",
+									"$ref": "#/properties/social/properties/mastodon/properties/api/definitions/api"
+								}
+							},
+							"additionalProperties": false,
+							"definitions": {
+								"api": {
+									"type": "object",
+									"required": ["instance_origin", "access_token"],
+									"title": "API 情報",
+									"properties": {
+										"instance_origin": {
+											"type": "string",
+											"title": "インスタンスのオリジン"
+										},
+										"access_token": {
+											"type": "string",
+											"title": "アクセストークン"
+										}
+									},
+									"additionalProperties": false
+								}
+							}
+						},
+						"message_prefix": {
+							"type": "string",
+							"title": "ツイート本文の冒頭"
+						},
+						"url_prefix": {
+							"type": "string",
+							"title": "記事 URL の冒頭"
+						},
+						"api_response": {
+							"type": "object",
+							"title": "API のレスポンス",
+							"required": ["message_success", "message_failure"],
+							"properties": {
+								"message_success": {
+									"type": "string",
+									"title": "成功時のメッセージ"
+								},
+								"message_failure": {
+									"type": "string",
+									"title": "失敗時のメッセージ"
+								}
+							},
+							"additionalProperties": false
 						}
 					},
 					"additionalProperties": false

--- a/packages/backend/node/@types/reqest.d.ts
+++ b/packages/backend/node/@types/reqest.d.ts
@@ -21,6 +21,7 @@ declare namespace BlogRequest {
 		relation: string | null;
 		public: boolean;
 		timestamp: boolean;
+		social: boolean;
 		media_overwrite: boolean;
 		action_add: boolean;
 		action_revise: boolean;

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -37,6 +37,7 @@
 		"jsdom": "^22.1.0",
 		"kill-port": "^2.0.1",
 		"log4js": "^6.9.1",
+		"masto": "^5.11.3",
 		"md5": "^2.3.0",
 		"mdast-util-definition-list": "^1.4.0",
 		"mdast-util-gfm-footnote": "^1.0.2",

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -213,6 +213,24 @@
 										</div>
 									</fieldset>
 								</div>
+								<%_ } else { _%>
+								<div class="p-form-grid__group">
+									<fieldset>
+										<legend class="p-form-grid__legend">外部サービス</legend>
+										<div class="p-form-grid__contents">
+											<div class="c-form-controls">
+												<label class="c-label -check">
+													<%_ if (requestQuery.social === 1) { _%>
+													<input type="checkbox" name="social" value="1" checked="" />
+													<%_ } else { _%>
+													<input type="checkbox" name="social" value="1" />
+													<%_ } _%>
+													<span class="c-label__text">ソーシャルサービスへ投稿</span>
+												</label>
+											</div>
+										</div>
+									</fieldset>
+								</div>
 								<%_ } _%>
 							</div>
 


### PR DESCRIPTION
#302 でツイート機能を削除したが、事実上それの Mastodon 版としての復活。以前との違いは以下のとおり。

- ハッシュタグ機能はナシ
- 投稿完了時のメッセージでトゥート URL を確認できるように
- ついでに投稿完了時のメッセージで記事ページの URL も確認できるように
- ↑は自動リンクしたいが、とりあえず現状はあくまで URL の記載のみ