### PR TITLE
アクセス解析が動いていなかったバグを修正

### DIFF
--- a/packages/frontend/script/analytics.ts
+++ b/packages/frontend/script/analytics.ts
@@ -5,4 +5,4 @@ var _paq: unknown[] = (window._paq = window._paq || []);
 _paq.push(['trackPageView']);
 _paq.push(['enableLinkTracking']);
 _paq.push(['setTrackerUrl', 'https://analytics.w0s.jp/matomo/matomo.php']);
-_paq.push(['setSiteId', '1']);
+_paq.push(['setSiteId', '2']);


### PR DESCRIPTION
#270 の修正で `setSiteId` の値が本体サイト（w0s.jp）のものに差し替わってしまっており、1か月以上アクセスログへの記録が行われていなかった。

当該箇所: https://github.com/SaekiTominaga/blog.w0s.jp/pull/270/files#diff-2188fdeca8c35fccb2c2ae2386789abb86b1c15dd1de4cf6cf6c0d73cdf7586e