### PR TITLE
記事投稿時の Mastodon トゥート機能が Followers-only になってたため Public に変更

### DIFF
--- a/packages/backend/node/src/controller/PostController.ts
+++ b/packages/backend/node/src/controller/PostController.ts
@@ -453,7 +453,6 @@ export default class PostController extends Controller implements ControllerInte
 
 			const status = await mastodon.v1.statuses.create({
 				status: message,
-				visibility: 'private',
 				language: 'ja',
 			});
 


### PR DESCRIPTION
#318 のバグ修正

テスト用に一時的に設定していた `visibility: 'private'` が残っていたので削除