### PR TITLE
Mastodon 投稿にハッシュタグ機能追加などの改善

### DIFF
--- a/packages/backend/configure/schema/post.json
+++ b/packages/backend/configure/schema/post.json
@@ -224,47 +224,33 @@
 				"mastodon": {
 					"type": "object",
 					"title": "Mastodon",
-					"required": ["api", "message_prefix", "url_prefix", "api_response"],
+					"required": ["api", "visibility", "message_prefix", "url_prefix", "api_response"],
 					"properties": {
 						"api": {
 							"type": "object",
 							"title": "API 情報",
-							"required": ["development", "production"],
+							"required": ["instance_origin", "access_token"],
 							"properties": {
-								"development": {
-									"type": "object",
-									"title": "開発用",
-									"$ref": "#/properties/social/properties/mastodon/properties/api/definitions/api"
+								"instance_origin": {
+									"type": "string",
+									"title": "インスタンスのオリジン"
 								},
-								"production": {
-									"type": "object",
-									"title": "本番用",
-									"$ref": "#/properties/social/properties/mastodon/properties/api/definitions/api"
+								"access_token": {
+									"type": "string",
+									"title": "アクセストークン"
 								}
 							},
-							"additionalProperties": false,
-							"definitions": {
-								"api": {
-									"type": "object",
-									"required": ["instance_origin", "access_token"],
-									"title": "API 情報",
-									"properties": {
-										"instance_origin": {
-											"type": "string",
-											"title": "インスタンスのオリジン"
-										},
-										"access_token": {
-											"type": "string",
-											"title": "アクセストークン"
-										}
-									},
-									"additionalProperties": false
-								}
-							}
+							"additionalProperties": false
+						},
+						"visibility": {
+							"type": "string",
+							"title": "トゥートの可視性",
+							"enum": ["public", "unlisted", "private", "direct"],
+							"description": "https://docs.joinmastodon.org/entities/Status/#visibility"
 						},
 						"message_prefix": {
 							"type": "string",
-							"title": "ツイート本文の冒頭"
+							"title": "トゥート本文の冒頭テキスト"
 						},
 						"url_prefix": {
 							"type": "string",

--- a/packages/backend/node/@types/reqest.d.ts
+++ b/packages/backend/node/@types/reqest.d.ts
@@ -22,6 +22,7 @@ declare namespace BlogRequest {
 		public: boolean;
 		timestamp: boolean;
 		social: boolean;
+		social_tag: string | null;
 		media_overwrite: boolean;
 		action_add: boolean;
 		action_revise: boolean;

--- a/packages/backend/node/src/controller/PostController.ts
+++ b/packages/backend/node/src/controller/PostController.ts
@@ -47,7 +47,7 @@ export default class PostController extends Controller implements ControllerInte
 
 	/**
 	 * @param configCommon - 共通設定
-	 * @param env - 共通設定
+	 * @param env - NODE_ENV
 	 */
 	constructor(configCommon: ConfigureCommon, env: Express.Env) {
 		super(configCommon);
@@ -438,12 +438,10 @@ export default class PostController extends Controller implements ControllerInte
 	 */
 	async #postSocial(requestQuery: BlogRequest.Post, entryUrl: string): Promise<PostResults> {
 		/* Mastodon */
-		const api = this.#env === 'development' ? this.#config.social.mastodon.api.development : this.#config.social.mastodon.api.production;
-
 		try {
 			const mastodon = await mastodonLogin({
-				url: api.instance_origin,
-				accessToken: api.access_token,
+				url: this.#config.social.mastodon.api.instance_origin,
+				accessToken: this.#config.social.mastodon.api.access_token,
 			});
 
 			let message = `${this.#config.social.mastodon.message_prefix}\n\n${requestQuery.title}\n${entryUrl}`;
@@ -453,6 +451,7 @@ export default class PostController extends Controller implements ControllerInte
 
 			const status = await mastodon.v1.statuses.create({
 				status: message,
+				visibility: this.#env === 'development' ? 'direct' : this.#config.social.mastodon.visibility, // https://docs.joinmastodon.org/entities/Status/#visibility
 				language: 'ja',
 			});
 

--- a/packages/backend/node/src/controller/PostController.ts
+++ b/packages/backend/node/src/controller/PostController.ts
@@ -83,6 +83,7 @@ export default class PostController extends Controller implements ControllerInte
 			public: RequestUtil.boolean(req.body['public']),
 			timestamp: RequestUtil.boolean(req.body['timestamp']),
 			social: RequestUtil.boolean(req.body['social']),
+			social_tag: RequestUtil.string(req.body['social_tag']),
 			media_overwrite: RequestUtil.boolean(req.body['mediaoverwrite']),
 			action_add: RequestUtil.boolean(req.body['actionadd']),
 			action_revise: RequestUtil.boolean(req.body['actionrev']),
@@ -445,7 +446,21 @@ export default class PostController extends Controller implements ControllerInte
 			});
 
 			let message = `${this.#config.social.mastodon.message_prefix}\n\n${requestQuery.title}\n${entryUrl}`;
-			if (requestQuery.description !== '') {
+			if (requestQuery.social_tag !== null && requestQuery.social_tag !== '') {
+				/* ハッシュタグ */
+				message += `\n\n${requestQuery.social_tag
+					.split(',')
+					.map((tag) => {
+						const tagTrimmed = tag.trim();
+						if (tagTrimmed === '') {
+							return '';
+						}
+						return `#${tagTrimmed}`;
+					})
+					.join(' ')}`;
+			}
+			if (requestQuery.description !== null && requestQuery.description !== '') {
+				/* 概要 */
 				message += `\n\n${requestQuery.description}`;
 			}
 

--- a/packages/backend/node/src/controller/PostController.ts
+++ b/packages/backend/node/src/controller/PostController.ts
@@ -129,7 +129,7 @@ export default class PostController extends Controller implements ControllerInte
 				topicPostResults.add(createFeedResult);
 				topicPostResults.add(createSitemapResult);
 				topicPostResults.add(await this.#createNewlyJson(dao));
-				if (requestQuery.social) {
+				if (requestQuery.public && requestQuery.social) {
 					topicPostResults.add(await this.#postSocial(requestQuery, entryUrl));
 				}
 			}

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -172,8 +172,10 @@
 										<legend class="p-form-grid__legend"><label for="fc-relation" class="c-label">関連記事</label></legend>
 										<div class="p-form-grid__contents">
 											<div class="c-form-controls">
-												<input id="fc-relation" class="c-input js-convert-trim" name="relation" value="<%= requestQuery.relation %>" maxlength="23" pattern="[1-9]{1}[0-9]*(,[1-9]{1}[0-9]*)*" style="--inline-size: 15em" />
-												<small>（カンマ区切り）</small>
+												<span>
+													<input id="fc-relation" class="c-input js-convert-trim" name="relation" value="<%= requestQuery.relation %>" maxlength="23" pattern="[1-9]{1}[0-9]*(,[1-9]{1}[0-9]*)*" style="--inline-size: 15em" />
+													<small>（カンマ区切り）</small>
+												</span>
 											</div>
 										</div>
 									</fieldset>
@@ -226,6 +228,13 @@
 													<input type="checkbox" name="social" value="1" />
 													<%_ } _%>
 													<span class="c-label__text">ソーシャルサービスへ投稿</span>
+												</label>
+											</div>
+											<div class="c-form-controls">
+												<label class="c-label -input">
+													<span class="c-label__text">ハッシュタグ</span>
+													<input id="fc-social-tag" class="c-input js-convert-trim" name="social_tag" value="<%= requestQuery.social_tag %>" maxlength="100" style="--inline-size: 15em" />
+													<small>（カンマ区切り）</small>
 												</label>
 											</div>
 										</div>


### PR DESCRIPTION
- ハッシュタグ機能を追加
- 記事の非公開状態ではソーシャル投稿を行わない（「公開状態」のチェックが外れた状態では、「ソーシャルサービスへ投稿」をチェックしていてもそれを無視して投稿処理をスルーする）
- dev 環境では API 接続先を変えていたが、それを廃止し、代わりに本番環境と同じ接続先に `visibility: direct` 状態で投稿するように変更
- 本番環境での `visibility` 状態を config ファイルで設定できるようにした