### PR TITLE
記事一覧のサムネイル画像処理から Twitter 関係を削除

### DIFF
--- a/packages/backend/configure/schema/category.json
+++ b/packages/backend/configure/schema/category.json
@@ -13,7 +13,7 @@
 		"image_external": {
 			"type": "object",
 			"title": "外部サービスの画像",
-			"required": ["amazon", "twitter"],
+			"required": ["amazon"],
 			"properties": {
 				"amazon": {
 					"type": "object",
@@ -28,26 +28,6 @@
 							"type": "integer",
 							"minimum": 1,
 							"title": "画像サイズ"
-						}
-					},
-					"additionalProperties": false
-				},
-				"twitter": {
-					"type": "object",
-					"title": "Twitter",
-					"required": ["origin", "params"],
-					"properties": {
-						"origin": {
-							"type": "string",
-							"title": "URL origin"
-						},
-						"params": {
-							"type": "object",
-							"title": "パラメーター",
-							"additionalProperties": {
-								"type": "string",
-								"title": "パラメーターの値"
-							}
 						}
 					},
 					"additionalProperties": false

--- a/packages/backend/configure/schema/list.json
+++ b/packages/backend/configure/schema/list.json
@@ -13,7 +13,7 @@
 		"image_external": {
 			"type": "object",
 			"title": "外部サービスの画像",
-			"required": ["amazon", "twitter"],
+			"required": ["amazon"],
 			"properties": {
 				"amazon": {
 					"type": "object",
@@ -28,26 +28,6 @@
 							"type": "integer",
 							"minimum": 1,
 							"title": "画像サイズ"
-						}
-					},
-					"additionalProperties": false
-				},
-				"twitter": {
-					"type": "object",
-					"title": "Twitter",
-					"required": ["origin", "params"],
-					"properties": {
-						"origin": {
-							"type": "string",
-							"title": "URL origin"
-						},
-						"params": {
-							"type": "object",
-							"title": "パラメーター",
-							"additionalProperties": {
-								"type": "string",
-								"title": "パラメーターの値"
-							}
 						}
 					},
 					"additionalProperties": false

--- a/packages/backend/node/src/controller/CategoryController.ts
+++ b/packages/backend/node/src/controller/CategoryController.ts
@@ -89,16 +89,6 @@ export default class CategoryController extends Controller implements Controller
 						imageExternal = paapi5ItemImageUrlParser.toString();
 						break;
 					}
-					case this.#config.image_external.twitter.origin: {
-						/* Twitter */
-						const { searchParams } = url;
-						for (const [name, value] of Object.entries(this.#config.image_external.twitter.params)) {
-							searchParams.set(name, value);
-						}
-						url.search = searchParams.toString();
-						imageExternal = url.toString();
-						break;
-					}
 					default:
 				}
 			}

--- a/packages/backend/node/src/controller/ListController.ts
+++ b/packages/backend/node/src/controller/ListController.ts
@@ -88,16 +88,6 @@ export default class ListController extends Controller implements ControllerInte
 						imageExternal = paapi5ItemImageUrlParser.toString();
 						break;
 					}
-					case this.#config.image_external.twitter.origin: {
-						/* Twitter */
-						const { searchParams } = url;
-						for (const [name, value] of Object.entries(this.#config.image_external.twitter.params)) {
-							searchParams.set(name, value);
-						}
-						url.search = searchParams.toString();
-						imageExternal = url.toString();
-						break;
-					}
 					default:
 				}
 			}


### PR DESCRIPTION
現状、外部サービスの画像使用は Amazon と YouTube のみであり、Twitter に関しては今後の利用予定もない。
単なる消し忘れと思われるので削除する。