### PR TITLE
インライン引用の中身が空の場合は `<q>` への変換をしない

### DIFF
--- a/packages/backend/node/src/markdown/toMdast/phrasing/quote.ts
+++ b/packages/backend/node/src/markdown/toMdast/phrasing/quote.ts
@@ -44,6 +44,10 @@ const toMdast = (): Plugin => {
 			const quoteValue = value.substring(quoteOpenIndex + QUOTE_OPEN.length, quoteCloseIndex);
 			const afterQuoteValue = value.substring(quoteCloseIndex + QUOTE_CLOSE.length);
 
+			if (quoteValue === '') {
+				return CONTINUE;
+			}
+
 			/* 引用のメタ情報を取得 */
 			const meta: Meta = {};
 


### PR DESCRIPTION
#340 の関連

- `{text}` → `<q>text</q>`
- `{ }` → `<q> </q>`
- `{}` → 変換しない（*New!*）