### PR TITLE
記事フッターの GitHub Issue リンクのラベルを変更（「○○する」の表現を排除）

### DIFF
--- a/views/entry.ejs
+++ b/views/entry.ejs
@@ -83,8 +83,8 @@
 									</li>
 									<li class="c-flex__item">
 										<a href="https://github.com/SaekiTominaga/blog.w0s.jp/issues/new/choose" class="c-button -github">
-											<img src="/image/icon/github.svg" alt="(GitHub)" width="16" height="16" class="c-button__icon" />
-											<span class="c-button__text">コメントを書く</span>
+											<img src="/image/icon/github.svg" alt="GitHub" width="16" height="16" class="c-button__icon" />
+											<span class="c-button__text">コメント <small>(Issue)</small></span>
 										</a>
 									</li>
 								</ul>


### PR DESCRIPTION
リンクラベルに「○○する」の表現はおかしいので単に「○○」に変更