### PR TITLE
リンクドメイン表記のマークアップを変更

### DIFF
--- a/packages/backend/node/__tests__/MarkdownBlock.test.js
+++ b/packages/backend/node/__tests__/MarkdownBlock.test.js
@@ -252,8 +252,8 @@ describe('link list', () => {
 		).toBe(
 			`
 <ul class="p-links">
-	<li><a href="http://example.com">list1</a><b class="c-domain">(example.com)</b> text</li>
-	<li><a href="http://example.com">list2</a><b class="c-domain">(example.com)</b> text</li>
+	<li><a href="http://example.com">list1</a><small class="c-domain">(<code>example.com</code>)</small> text</li>
+	<li><a href="http://example.com">list2</a><small class="c-domain">(<code>example.com</code>)</small> text</li>
 </ul>
 `.trim(),
 		);
@@ -274,8 +274,8 @@ describe('link list', () => {
 		).toBe(
 			`
 <ul class="p-list">
-	<li><a href="http://example.com">list1</a><b class="c-domain">(example.com)</b> text</li>
-	<li><a href="http://example.com">list2</a><b class="c-domain">(example.com)</b> text</li>
+	<li><a href="http://example.com">list1</a><small class="c-domain">(<code>example.com</code>)</small> text</li>
+	<li><a href="http://example.com">list2</a><small class="c-domain">(<code>example.com</code>)</small> text</li>
 	<li>list3</li>
 </ul>
 `.trim(),
@@ -587,7 +587,7 @@ describe('blockquote', () => {
 			`
 <figure>
 	<blockquote class="p-quote" lang="en" cite="http://example.com"><p>quote</p></blockquote>
-	<figcaption class="c-caption -meta"><a href="http://example.com">引用元</a><b class="c-domain">(example.com)</b></figcaption>
+	<figcaption class="c-caption -meta"><a href="http://example.com">引用元</a><small class="c-domain">(<code>example.com</code>)</small></figcaption>
 </figure>
 `.trim(),
 		);
@@ -1108,7 +1108,9 @@ describe('YouTube', () => {
 			`
 <figure>
 	<div class="p-embed"><iframe src="https://www.youtube-nocookie.com/embed/1234567890?cc_load_policy=1" allow="encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="640" height="360" class="p-embed__frame" style="--aspect-ratio: 640/360"></iframe></div>
-	<figcaption class="c-caption"><a href="https://www.youtube.com/watch?v=1234567890">title&lt;title> title</a><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon" /></figcaption>
+	<figcaption class="c-caption">
+		<a href="https://www.youtube.com/watch?v=1234567890">title&lt;title> title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon" /></small>
+	</figcaption>
 </figure>
 `.trim(),
 		);
@@ -1128,7 +1130,9 @@ describe('YouTube', () => {
 			`
 <figure>
 	<div class="p-embed"><iframe src="https://www.youtube-nocookie.com/embed/1234567890?cc_load_policy=1" allow="encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="100" height="150" class="p-embed__frame" style="--aspect-ratio: 100/150"></iframe></div>
-	<figcaption class="c-caption"><a href="https://www.youtube.com/watch?v=1234567890">title&lt;title> title</a><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon" /></figcaption>
+	<figcaption class="c-caption">
+		<a href="https://www.youtube.com/watch?v=1234567890">title&lt;title> title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon" /></small>
+	</figcaption>
 </figure>
 `.trim(),
 		);
@@ -1148,7 +1152,9 @@ describe('YouTube', () => {
 			`
 <figure>
 	<div class="p-embed"><iframe src="https://www.youtube-nocookie.com/embed/1234567890?cc_load_policy=1&amp;start=10" allow="encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="640" height="360" class="p-embed__frame" style="--aspect-ratio: 640/360"></iframe></div>
-	<figcaption class="c-caption"><a href="https://www.youtube.com/watch?v=1234567890&amp;t=10s">title</a><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon" /></figcaption>
+	<figcaption class="c-caption">
+		<a href="https://www.youtube.com/watch?v=1234567890&amp;t=10s">title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon" /></small>
+	</figcaption>
 </figure>
 `.trim(),
 		);
@@ -1168,7 +1174,9 @@ describe('YouTube', () => {
 			`
 <figure>
 	<div class="p-embed"><iframe src="https://www.youtube-nocookie.com/embed/1234567890?cc_load_policy=1&amp;start=10" allow="encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="100" height="150" class="p-embed__frame" style="--aspect-ratio: 100/150"></iframe></div>
-	<figcaption class="c-caption"><a href="https://www.youtube.com/watch?v=1234567890&amp;t=10s">title</a><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon" /></figcaption>
+	<figcaption class="c-caption">
+		<a href="https://www.youtube.com/watch?v=1234567890&amp;t=10s">title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon" /></small>
+	</figcaption>
 </figure>
 `.trim(),
 		);

--- a/packages/backend/node/__tests__/MarkdownBlock.test.js
+++ b/packages/backend/node/__tests__/MarkdownBlock.test.js
@@ -1109,7 +1109,7 @@ describe('YouTube', () => {
 <figure>
 	<div class="p-embed"><iframe src="https://www.youtube-nocookie.com/embed/1234567890?cc_load_policy=1" allow="encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="640" height="360" class="p-embed__frame" style="--aspect-ratio: 640/360"></iframe></div>
 	<figcaption class="c-caption">
-		<a href="https://www.youtube.com/watch?v=1234567890">title&lt;title> title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon" /></small>
+		<a href="https://www.youtube.com/watch?v=1234567890">title&lt;title> title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" /></small>
 	</figcaption>
 </figure>
 `.trim(),
@@ -1131,7 +1131,7 @@ describe('YouTube', () => {
 <figure>
 	<div class="p-embed"><iframe src="https://www.youtube-nocookie.com/embed/1234567890?cc_load_policy=1" allow="encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="100" height="150" class="p-embed__frame" style="--aspect-ratio: 100/150"></iframe></div>
 	<figcaption class="c-caption">
-		<a href="https://www.youtube.com/watch?v=1234567890">title&lt;title> title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon" /></small>
+		<a href="https://www.youtube.com/watch?v=1234567890">title&lt;title> title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" /></small>
 	</figcaption>
 </figure>
 `.trim(),
@@ -1153,7 +1153,7 @@ describe('YouTube', () => {
 <figure>
 	<div class="p-embed"><iframe src="https://www.youtube-nocookie.com/embed/1234567890?cc_load_policy=1&amp;start=10" allow="encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="640" height="360" class="p-embed__frame" style="--aspect-ratio: 640/360"></iframe></div>
 	<figcaption class="c-caption">
-		<a href="https://www.youtube.com/watch?v=1234567890&amp;t=10s">title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon" /></small>
+		<a href="https://www.youtube.com/watch?v=1234567890&amp;t=10s">title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" /></small>
 	</figcaption>
 </figure>
 `.trim(),
@@ -1175,7 +1175,7 @@ describe('YouTube', () => {
 <figure>
 	<div class="p-embed"><iframe src="https://www.youtube-nocookie.com/embed/1234567890?cc_load_policy=1&amp;start=10" allow="encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="100" height="150" class="p-embed__frame" style="--aspect-ratio: 100/150"></iframe></div>
 	<figcaption class="c-caption">
-		<a href="https://www.youtube.com/watch?v=1234567890&amp;t=10s">title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" class="c-link-icon" /></small>
+		<a href="https://www.youtube.com/watch?v=1234567890&amp;t=10s">title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" /></small>
 	</figcaption>
 </figure>
 `.trim(),

--- a/packages/backend/node/__tests__/MarkdownPhrasing.test.js
+++ b/packages/backend/node/__tests__/MarkdownPhrasing.test.js
@@ -31,7 +31,7 @@ describe('link', () => {
 	test('URL &', async () => {
 		const markdown = new Markdown();
 		expect(await format(await markdown.toHtml('text1[link1](https://example.com/?foo=hoge&bar=piyo)text2'))).toBe(
-			'<p>text1<a href="https://example.com/?foo=hoge&amp;bar=piyo">link1</a><small class="c-domain">(<code>example.com</code>)</small>text2</p>'.trim(),
+			'<p>text1<a href="https://example.com/?foo=hoge&amp;bar=piyo">link1</a><small class="c-domain">(<code>example.com</code>)</small> text2</p>'.trim(),
 		);
 	});
 
@@ -46,7 +46,7 @@ describe('link', () => {
 		const markdown = new Markdown();
 		expect(await format(await markdown.toHtml('text1[link1](https://github.com/)text2'))).toBe(
 			`<p>
-	text1<a href="https://github.com/">link1</a><small class="c-domain"><img src="/image/icon/github.svg" alt="(GitHub)" width="16" height="16" class="c-link-icon" /></small>text2
+	text1<a href="https://github.com/">link1</a><small class="c-domain"><img src="/image/icon/github.svg" alt="(GitHub)" width="16" height="16" /></small> text2
 </p>`.trim(),
 		);
 	});
@@ -54,7 +54,7 @@ describe('link', () => {
 	test('PDF', async () => {
 		const markdown = new Markdown();
 		expect(await format(await markdown.toHtml('text1[link1](https://example.com/foo.pdf)text2'))).toBe(
-			'<p>text1<a href="https://example.com/foo.pdf">link1</a><img src="/image/icon/pdf.png" alt="(PDF)" width="16" height="16" class="c-link-icon" /><small class="c-domain">(<code>example.com</code>)</small>text2</p>'.trim(),
+			'<p>text1<a href="https://example.com/foo.pdf">link1</a><img src="/image/icon/pdf.png" alt="(PDF)" width="16" height="16" class="c-link-icon" /><small class="c-domain">(<code>example.com</code>)</small> text2</p>'.trim(),
 		);
 	});
 
@@ -67,7 +67,7 @@ describe('link', () => {
 		const markdown = new Markdown();
 		expect(await format(await markdown.toHtml('text1[link1](amazon:4065199816)text2'))).toBe(
 			`<p>
-	text1<a href="https://www.amazon.co.jp/dp/4065199816/ref=nosim?tag=w0s.jp-22">link1</a><small class="c-domain"><img src="/image/icon/amazon.png" alt="(Amazon)" width="16" height="16" class="c-link-icon" /></small>text2
+	text1<a href="https://www.amazon.co.jp/dp/4065199816/ref=nosim?tag=w0s.jp-22">link1</a><small class="c-domain"><img src="/image/icon/amazon.png" alt="(Amazon)" width="16" height="16" /></small> text2
 </p>`.trim(),
 		);
 	});
@@ -100,7 +100,7 @@ describe('quote', () => {
 			`
 <p>
 	text1<a href="https://example.com/"><q cite="https://example.com/">quote1</q></a
-	><small class="c-domain">(<code>example.com</code>)</small>text2
+	><small class="c-domain">(<code>example.com</code>)</small> text2
 </p>
 `.trim(),
 		);
@@ -129,7 +129,7 @@ describe('quote', () => {
 			`
 <p>
 	text1<a href="https://example.com/"><q lang="en" cite="https://example.com/">quote1</q></a
-	><small class="c-domain">(<code>example.com</code>)</small>text2
+	><small class="c-domain">(<code>example.com</code>)</small> text2
 </p>
 `.trim(),
 		);

--- a/packages/backend/node/__tests__/MarkdownPhrasing.test.js
+++ b/packages/backend/node/__tests__/MarkdownPhrasing.test.js
@@ -31,7 +31,7 @@ describe('link', () => {
 	test('URL &', async () => {
 		const markdown = new Markdown();
 		expect(await format(await markdown.toHtml('text1[link1](https://example.com/?foo=hoge&bar=piyo)text2'))).toBe(
-			'<p>text1<a href="https://example.com/?foo=hoge&amp;bar=piyo">link1</a><b class="c-domain">(example.com)</b>text2</p>'.trim(),
+			'<p>text1<a href="https://example.com/?foo=hoge&amp;bar=piyo">link1</a><small class="c-domain">(<code>example.com</code>)</small>text2</p>'.trim(),
 		);
 	});
 
@@ -45,14 +45,16 @@ describe('link', () => {
 	test('icon', async () => {
 		const markdown = new Markdown();
 		expect(await format(await markdown.toHtml('text1[link1](https://github.com/)text2'))).toBe(
-			'<p>text1<a href="https://github.com/">link1</a><img src="/image/icon/github.svg" alt="(GitHub)" width="16" height="16" class="c-link-icon" />text2</p>'.trim(),
+			`<p>
+	text1<a href="https://github.com/">link1</a><small class="c-domain"><img src="/image/icon/github.svg" alt="(GitHub)" width="16" height="16" class="c-link-icon" /></small>text2
+</p>`.trim(),
 		);
 	});
 
 	test('PDF', async () => {
 		const markdown = new Markdown();
 		expect(await format(await markdown.toHtml('text1[link1](https://example.com/foo.pdf)text2'))).toBe(
-			'<p>text1<a href="https://example.com/foo.pdf">link1</a><img src="/image/icon/pdf.png" alt="(PDF)" width="16" height="16" class="c-link-icon" /><b class="c-domain">(example.com)</b>text2</p>'.trim(),
+			'<p>text1<a href="https://example.com/foo.pdf">link1</a><img src="/image/icon/pdf.png" alt="(PDF)" width="16" height="16" class="c-link-icon" /><small class="c-domain">(<code>example.com</code>)</small>text2</p>'.trim(),
 		);
 	});
 
@@ -64,7 +66,9 @@ describe('link', () => {
 	test('amazon', async () => {
 		const markdown = new Markdown();
 		expect(await format(await markdown.toHtml('text1[link1](amazon:4065199816)text2'))).toBe(
-			'<p>text1<a href="https://www.amazon.co.jp/dp/4065199816/ref=nosim?tag=w0s.jp-22">link1</a><img src="/image/icon/amazon.png" alt="(Amazon)" width="16" height="16" class="c-link-icon" />text2</p>'.trim(),
+			`<p>
+	text1<a href="https://www.amazon.co.jp/dp/4065199816/ref=nosim?tag=w0s.jp-22">link1</a><small class="c-domain"><img src="/image/icon/amazon.png" alt="(Amazon)" width="16" height="16" class="c-link-icon" /></small>text2
+</p>`.trim(),
 		);
 	});
 
@@ -96,7 +100,7 @@ describe('quote', () => {
 			`
 <p>
 	text1<a href="https://example.com/"><q cite="https://example.com/">quote1</q></a
-	><b class="c-domain">(example.com)</b>text2
+	><small class="c-domain">(<code>example.com</code>)</small>text2
 </p>
 `.trim(),
 		);
@@ -125,7 +129,7 @@ describe('quote', () => {
 			`
 <p>
 	text1<a href="https://example.com/"><q lang="en" cite="https://example.com/">quote1</q></a
-	><b class="c-domain">(example.com)</b>text2
+	><small class="c-domain">(<code>example.com</code>)</small>text2
 </p>
 `.trim(),
 		);

--- a/packages/backend/node/src/markdown/lib/HastUtil.ts
+++ b/packages/backend/node/src/markdown/lib/HastUtil.ts
@@ -102,13 +102,17 @@ export default class MdastUtil {
 								alt: `(${hostInfo.altText})`,
 								width: '16',
 								height: '16',
-								className: 'c-link-icon',
 							},
 							children: [],
 						},
 					],
 				});
 			}
+
+			info.push({
+				type: 'text',
+				value: ' ',
+			});
 		}
 
 		return info;

--- a/packages/backend/node/src/markdown/lib/HastUtil.ts
+++ b/packages/backend/node/src/markdown/lib/HastUtil.ts
@@ -61,29 +61,52 @@ export default class MdastUtil {
 			if (typeof hostInfo === 'string') {
 				info.push({
 					type: 'element',
-					tagName: 'b',
+					tagName: 'small',
 					properties: {
 						className: 'c-domain',
 					},
 					children: [
 						{
 							type: 'text',
-							value: `(${hostInfo})`,
+							value: '(',
+						},
+						{
+							type: 'element',
+							tagName: 'code',
+							children: [
+								{
+									type: 'text',
+									value: hostInfo,
+								},
+							],
+						},
+						{
+							type: 'text',
+							value: ')',
 						},
 					],
 				});
 			} else {
 				info.push({
 					type: 'element',
-					tagName: 'img',
+					tagName: 'small',
 					properties: {
-						src: `/image/icon/${hostInfo.fileName}`,
-						alt: `(${hostInfo.altText})`,
-						width: '16',
-						height: '16',
-						className: 'c-link-icon',
+						className: 'c-domain',
 					},
-					children: [],
+					children: [
+						{
+							type: 'element',
+							tagName: 'img',
+							properties: {
+								src: `/image/icon/${hostInfo.fileName}`,
+								alt: `(${hostInfo.altText})`,
+								width: '16',
+								height: '16',
+								className: 'c-link-icon',
+							},
+							children: [],
+						},
+					],
 				});
 			}
 		}

--- a/packages/backend/node/src/markdown/toHast/block/embedded.ts
+++ b/packages/backend/node/src/markdown/toHast/block/embedded.ts
@@ -239,7 +239,6 @@ export const xEmbeddedYouTubeToHast = (_state: H, node: XEmbeddedYouTube): HastE
 									alt: '(YouTube)',
 									width: '16',
 									height: '16',
-									className: ['c-link-icon'],
 								},
 								children: [],
 							},

--- a/packages/backend/node/src/markdown/toHast/block/embedded.ts
+++ b/packages/backend/node/src/markdown/toHast/block/embedded.ts
@@ -226,15 +226,24 @@ export const xEmbeddedYouTubeToHast = (_state: H, node: XEmbeddedYouTube): HastE
 					},
 					{
 						type: 'element',
-						tagName: 'img',
+						tagName: 'small',
 						properties: {
-							src: '/image/icon/youtube.svg',
-							alt: '(YouTube)',
-							width: '16',
-							height: '16',
-							className: ['c-link-icon'],
+							className: 'c-domain',
 						},
-						children: [],
+						children: [
+							{
+								type: 'element',
+								tagName: 'img',
+								properties: {
+									src: '/image/icon/youtube.svg',
+									alt: '(YouTube)',
+									width: '16',
+									height: '16',
+									className: ['c-link-icon'],
+								},
+								children: [],
+							},
+						],
 					},
 				],
 			},

--- a/packages/frontend/style/foundation/_elements.css
+++ b/packages/frontend/style/foundation/_elements.css
@@ -71,11 +71,15 @@ code {
 	padding-block: 0.25em;
 	color: var(--color-green);
 
-	:is(h1, h2, h3, h4, h5, h6, hgroup, pre, a) & {
-		border-radius: 0;
-		background-color: transparent;
-		padding-block: 0;
+	:is(h1, h2, h3, h4, h5, h6, hgroup, pre, :any-link, .c-domain) & {
+		border-radius: initial;
+		background-color: initial;
+		padding-block: initial;
 		color: inherit;
+	}
+
+	.c-domain & {
+		font-family: inherit;
 	}
 }
 

--- a/packages/frontend/style/foundation/_elements.css
+++ b/packages/frontend/style/foundation/_elements.css
@@ -71,7 +71,7 @@ code {
 	padding-block: 0.25em;
 	color: var(--color-green);
 
-	:is(h1, h2, h3, h4, h5, h6, hgroup, pre, :any-link, .c-domain) & {
+	:is(h1, h2, h3, h4, h5, h6, hgroup, pre, a, .c-domain) & {
 		border-radius: initial;
 		background-color: initial;
 		padding-block: initial;

--- a/packages/frontend/style/object/component/_text.css
+++ b/packages/frontend/style/object/component/_text.css
@@ -144,12 +144,22 @@
 .c-domain {
 	--_font-size: calc(100% / var(--font-ratio-1));
 
-	margin-inline: 0.25em;
 	color: var(--color-gray);
 	font-size: var(--_font-size);
+	word-break: break-all;
 
-	&:has(.c-link-icon) {
+	&:has(img) {
 		--_font-size: inherit;
+	}
+
+	a + & {
+		margin-inline-start: 0.25em;
+	}
+
+	& > img {
+		vertical-align: -0.05lh;
+		inline-size: auto;
+		block-size: 1em;
 	}
 }
 

--- a/packages/frontend/style/object/component/_text.css
+++ b/packages/frontend/style/object/component/_text.css
@@ -142,10 +142,15 @@
 
 /* ===== ドメイン表記 ===== */
 .c-domain {
+	--_font-size: calc(100% / var(--font-ratio-1));
+
 	margin-inline: 0.25em;
 	color: var(--color-gray);
-	font-weight: var(--font-weight-normal);
-	font-size: calc(100% / var(--font-ratio-1));
+	font-size: var(--_font-size);
+
+	&:has(.c-link-icon) {
+		--_font-size: inherit;
+	}
 }
 
 /* ===== 記事メタデータ ===== */


### PR DESCRIPTION
- `<b>` 要素を止めて `<small><code>` に置き換える
- アイコンの場合も `<small>` でマークアップする
- CSS の設定に `:has()` を使ったので、本番環境反映は Firefox 121 正式版がリリースされる2023年12月19日以降とする 

## テキストの場合

```diff
- <b class="c-domain">(example.com)</b>
+ <small class="c-domain">(<code>example.com</code>)</small>
```

## アイコンの場合

```diff
- <img src="/image/icon/example.svg" alt="(Example)" width="16" height="16" class="c-link-icon" />
+ <small class="c-domain"><img src="/image/icon/example.png" alt="(Example)" width="16" height="16" /></small>
```
