### PR TITLE
Mastodon 投稿処理で `status.url` が取得不能なときは `status.uri` で代替する

### DIFF
--- a/packages/backend/node/src/process/PostMastodon.ts
+++ b/packages/backend/node/src/process/PostMastodon.ts
@@ -33,7 +33,7 @@ export default class CreateNewlyJson {
 		requestQuery: BlogRequest.Post,
 		entryUrl: string,
 	): Promise<{
-		url: string | null; // A link to the status's HTML representation
+		url: string;
 	}> {
 		const mastodon = mastodonRest({
 			url: this.#config.api.instance_origin,
@@ -62,7 +62,7 @@ export default class CreateNewlyJson {
 		});
 
 		return {
-			url: status.url ?? null,
+			url: status.url ?? status.uri,
 		};
 	}
 }


### PR DESCRIPTION
| プロパティ | サンプル | 注意点 |
|-|-|-|
| `url` | https://fedibird.com/@SaekiTominaga/XXX | null が返ってきたりプロパティ自体が存在しないケースがあるらしい（条件不明） |
| `uri` | https://fedibird.com/users/SaekiTominaga/statuses/XXX | string が返ってくることが保障されている |
