### PR TITLE
Markuplint v4.1 にアップデート

### DIFF
--- a/.markuplintrc
+++ b/.markuplintrc
@@ -7,6 +7,7 @@
 	},
 	"excludeFiles": [
 		"views/feed/*.ejs",
+		"views/social/*.ejs",
 		"views/xml/*.ejs"
 	],
 	"rules": {
@@ -18,7 +19,6 @@
 			"s",
 			"i",
 			"u",
-			"br",
 			"wbr",
 			"area"
 		],

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
 			],
 			"devDependencies": {
 				"@csstools/postcss-global-data": "^2.1.1",
-				"@markuplint/ejs-parser": "^3.12.0",
+				"@markuplint/ejs-parser": "^4.1.1",
 				"@rollup/plugin-commonjs": "^25.0.7",
 				"@rollup/plugin-node-resolve": "^15.2.3",
 				"@rollup/plugin-terser": "^0.4.4",
 				"@rollup/plugin-typescript": "^11.1.6",
 				"@w0s/eslint-config": "^5.1.0",
-				"@w0s/markuplint-config": "^2.5.1",
+				"@w0s/markuplint-config": "^3.1.0",
 				"@w0s/stylelint-config": "^2.0.1",
 				"@w0s/tsconfig": "^1.4.1",
 				"ajv-cli": "^5.0.0",
@@ -27,7 +27,7 @@
 				"eslint": "^8.56.0",
 				"jest": "^29.7.0",
 				"json-schema-to-typescript": "^13.1.2",
-				"markuplint": "^3.15.0",
+				"markuplint": "^4.1.1",
 				"nodemon": "^3.0.3",
 				"npm-run-all": "^4.1.5",
 				"onchange": "^7.1.0",
@@ -796,6 +796,8 @@
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
 			"integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/trace-mapping": "0.3.9"
 			},
@@ -808,6 +810,8 @@
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
 			"integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.0.3",
 				"@jridgewell/sourcemap-codec": "^1.4.10"
@@ -1678,80 +1682,95 @@
 				"node": ">=6.0"
 			}
 		},
-		"node_modules/@markuplint/config-presets": {
-			"version": "3.9.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/config-presets/-/config-presets-3.9.0.tgz",
-			"integrity": "sha512-tZ4hwilGWec+EzUs0W1Hr4VyNMR10vH2lorPKuWvQVLntjZ6BKsL9fF2AYb/XnoQWc3Xbt8/nhhgxgOlVNasGA==",
-			"dev": true
-		},
-		"node_modules/@markuplint/create-rule-helper": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/create-rule-helper/-/create-rule-helper-3.15.0.tgz",
-			"integrity": "sha512-p1APXz5fMRxPZQKPy/Ht2jiIYzrnb+Pp/k1JU6TsbdcAPg9MlQ+mq676c+R8sYhSzPZ30YBqAPaD4eSWxyhjsg==",
+		"node_modules/@markuplint/cli-utils": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@markuplint/cli-utils/-/cli-utils-4.0.1.tgz",
+			"integrity": "sha512-PvHnnnXo/Q5IbG7OMoSHJ7/cbAfC8sZIZea84TkTKMwwj/hm+gttSd5X2YvPZyBZeKlYhtUdafQorEyg/Llw0A==",
 			"dev": true,
 			"dependencies": {
-				"@markuplint/ml-core": "3.15.0",
-				"glob": "^10.3.10",
-				"prettier": "2",
-				"ts-node": "^10.9.1",
-				"tslib": "^2.6.2",
-				"typescript": "^5.3.2"
+				"cli-color": "^2.0.3",
+				"detect-installed": "^2.0.4",
+				"eastasianwidth": "^0.2.0",
+				"enquirer": "^2.4.1",
+				"has-yarn": "^3.0.0",
+				"strip-ansi": "^7.1.0"
 			}
 		},
-		"node_modules/@markuplint/create-rule-helper/node_modules/prettier": {
-			"version": "2.8.8",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
-			"integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
+		"node_modules/@markuplint/cli-utils/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
 			"dev": true,
-			"bin": {
-				"prettier": "bin-prettier.js"
-			},
 			"engines": {
-				"node": ">=10.13.0"
+				"node": ">=12"
 			},
 			"funding": {
-				"url": "https://github.com/prettier/prettier?sponsor=1"
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
 			}
 		},
-		"node_modules/@markuplint/ejs-parser": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/ejs-parser/-/ejs-parser-3.12.0.tgz",
-			"integrity": "sha512-v3FxypynvqO4KCbmqmpe90m/I0GCi/lq71cgTfuKIm10a8E4Juhdz9LgfFnWALJcBhjLRCn0/suJemDX2FFD7Q==",
+		"node_modules/@markuplint/cli-utils/node_modules/has-yarn": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-3.0.0.tgz",
+			"integrity": "sha512-IrsVwUHhEULx3R8f/aA8AHuEzAorplsab/v8HBzEiIukwq5i/EC+xmOW+HfP1OaDP+2JkgT1yILHN2O3UFIbcA==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@markuplint/cli-utils/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
 			"dev": true,
 			"dependencies": {
-				"@markuplint/html-parser": "3.13.0",
-				"@markuplint/ml-ast": "3.2.0",
-				"@markuplint/parser-utils": "3.13.0"
+				"ansi-regex": "^6.0.1"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
+			}
+		},
+		"node_modules/@markuplint/config-presets": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@markuplint/config-presets/-/config-presets-4.1.0.tgz",
+			"integrity": "sha512-q9YJNRVFblJUXFJA54DYwDcwLanTf1AtCXKPNj+iqq2VdTiOEZ61McCENS3LeySmoomTAP90pvcc/j4UlH1kqQ==",
+			"dev": true
+		},
+		"node_modules/@markuplint/ejs-parser": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@markuplint/ejs-parser/-/ejs-parser-4.1.1.tgz",
+			"integrity": "sha512-lcxvTCJhY/3vjUH6KeRGIttzkPWN6DNPrsrKzuuVeBWfhbaBsgPIFcJkSUEJJzgIMjf69+HzxdGqzKn4Gl6m/g==",
+			"dev": true,
+			"dependencies": {
+				"@markuplint/html-parser": "4.1.1"
 			}
 		},
 		"node_modules/@markuplint/file-resolver": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/file-resolver/-/file-resolver-3.15.0.tgz",
-			"integrity": "sha512-WCHZuLoZIvJz7+X3Hq4De8VcXeZtJL9PYwvplr+4uZDxChE6gj9/TyQIYVkWyfYC5d3YSvPWGPHYXfLfrGLxSg==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@markuplint/file-resolver/-/file-resolver-4.1.1.tgz",
+			"integrity": "sha512-seKt93Zf8JCjCKMfGjOvs6TuukQvpKTsPyDqAUAu77q4plzvVBXlxuOgn3Lb4UrjU+z6qwpFyIroL/n+QXR7AQ==",
 			"dev": true,
 			"dependencies": {
-				"@markuplint/html-parser": "3.13.0",
-				"@markuplint/ml-ast": "3.2.0",
-				"@markuplint/ml-config": "3.14.0",
-				"@markuplint/ml-core": "3.15.0",
-				"@markuplint/ml-spec": "3.14.0",
-				"@markuplint/parser-utils": "3.13.0",
-				"@markuplint/selector": "3.14.0",
-				"@markuplint/shared": "3.8.0",
-				"cosmiconfig": "^8.3.6",
-				"cosmiconfig-typescript-loader": "^5.0.0",
-				"glob": "^10.3.10",
-				"ignore": "^5.3.0",
+				"@markuplint/html-parser": "4.1.1",
+				"@markuplint/ml-ast": "4.0.1",
+				"@markuplint/ml-config": "4.1.1",
+				"@markuplint/ml-core": "4.1.1",
+				"@markuplint/ml-spec": "4.0.2",
+				"@markuplint/parser-utils": "4.1.1",
+				"@markuplint/selector": "4.1.1",
+				"@markuplint/shared": "4.0.1",
+				"cosmiconfig": "^9.0.0",
+				"debug": "^4.3.4",
+				"glob": "^10.3.6",
+				"ignore": "^5.3.1",
 				"jsonc": "^2.0.0",
-				"minimatch": "^9.0.3",
-				"tslib": "^2.6.2"
+				"minimatch": "^9.0.3"
 			}
-		},
-		"node_modules/@markuplint/file-resolver/node_modules/argparse": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
 		},
 		"node_modules/@markuplint/file-resolver/node_modules/brace-expansion": {
 			"version": "2.0.1",
@@ -1760,44 +1779,6 @@
 			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
-			}
-		},
-		"node_modules/@markuplint/file-resolver/node_modules/cosmiconfig": {
-			"version": "8.3.6",
-			"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.3.6.tgz",
-			"integrity": "sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==",
-			"dev": true,
-			"dependencies": {
-				"import-fresh": "^3.3.0",
-				"js-yaml": "^4.1.0",
-				"parse-json": "^5.2.0",
-				"path-type": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/d-fischer"
-			},
-			"peerDependencies": {
-				"typescript": ">=4.9.5"
-			},
-			"peerDependenciesMeta": {
-				"typescript": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@markuplint/file-resolver/node_modules/js-yaml": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-			"dev": true,
-			"dependencies": {
-				"argparse": "^2.0.1"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/@markuplint/file-resolver/node_modules/minimatch": {
@@ -1816,16 +1797,15 @@
 			}
 		},
 		"node_modules/@markuplint/html-parser": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/html-parser/-/html-parser-3.13.0.tgz",
-			"integrity": "sha512-09GX6V8BmYVIlWECIrV3OVMdKhwhbAlLyvAGnm31qV974gR1zD5kFGmr9OSugZJD24Htqofjm2aI2P15HfDdCg==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@markuplint/html-parser/-/html-parser-4.1.1.tgz",
+			"integrity": "sha512-OHeGCXpSofRbE5eTBHpXaP8p+ab7fA1zusRirlkknEC818bPJxiYK8NbIsGg/i55ckF5xnnGvCyQR/egSfKGsw==",
 			"dev": true,
 			"dependencies": {
-				"@markuplint/ml-ast": "3.2.0",
-				"@markuplint/parser-utils": "3.13.0",
+				"@markuplint/ml-ast": "4.0.1",
+				"@markuplint/parser-utils": "4.1.1",
 				"parse5": "7.1.2",
-				"tslib": "^2.6.2",
-				"type-fest": "^4.8.2"
+				"type-fest": "^4.10.2"
 			}
 		},
 		"node_modules/@markuplint/html-parser/node_modules/type-fest": {
@@ -1841,40 +1821,40 @@
 			}
 		},
 		"node_modules/@markuplint/html-spec": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/html-spec/-/html-spec-3.14.0.tgz",
-			"integrity": "sha512-h36UdqgMQibsoj+tK3CE+vhV/0MzPbipxT8VmDRPliC667Dk6eAahod7Ma3CA5MHGapnjlAneiXyurddGFTXcw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@markuplint/html-spec/-/html-spec-4.1.1.tgz",
+			"integrity": "sha512-VRCxhS7BgfBvbwJTBNH4GEOGaYVkw9kAhvcdEqZPJ8ottzstw4mx8Z/2Qdz0OyMhMnFKTCvoqUuePBqk5bf+PA==",
 			"dev": true,
 			"dependencies": {
-				"@markuplint/ml-spec": "3.14.0"
+				"@markuplint/ml-spec": "4.0.2"
 			}
 		},
 		"node_modules/@markuplint/i18n": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/i18n/-/i18n-3.12.0.tgz",
-			"integrity": "sha512-1R0KwrVSKdSJG3PkZOemrOIMIYEKG8ZXMOReeGnLcoAA7oArOj7yhLhdVbnKbMyThRMIN3Fu3iEp2/20OeUU6Q==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@markuplint/i18n/-/i18n-4.1.0.tgz",
+			"integrity": "sha512-+kKJH9OJhLBVpDU0TlrOJjXxC8GKK0lXjnced8WtrvJ/FEvXNhbsMXUKdwsKJZnjnhQGrnOuUOWWeTF8DNankA==",
 			"dev": true
 		},
 		"node_modules/@markuplint/ml-ast": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/ml-ast/-/ml-ast-3.2.0.tgz",
-			"integrity": "sha512-qZJ0GTdGx1+2INEjfpSufu0143RgNqzfs9cA4TMdt9V18qdhSH1swWaMLiY0JJdnfJ4ui2uwxzg9Mhdtu0EINQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@markuplint/ml-ast/-/ml-ast-4.0.1.tgz",
+			"integrity": "sha512-7ZrgvUyPQ4YmUor+Iv/aHcnEVtktN88TNvmDNokLzMZlBxc5alpoCPAv3cJvU4t+dAgW+1P6SnZ2hVGaJkep6A==",
 			"dev": true
 		},
 		"node_modules/@markuplint/ml-config": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/ml-config/-/ml-config-3.14.0.tgz",
-			"integrity": "sha512-KSmiKCKLg5nfnicx8OEPZUuelOBvYJ0hh82w5Z+PN8IruZF0C8vuoQ7zNSVTvLtyc97G1g83uk660hYe6/aJGg==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@markuplint/ml-config/-/ml-config-4.1.1.tgz",
+			"integrity": "sha512-QGf7vwDgNzp+++XF/J+pbnfDvFAaYXqM62fw5krCDzUiTgsCvEHqzGnYXmbLS+doQC8Z+n1et11yIhstPdz05w==",
 			"dev": true,
 			"dependencies": {
-				"@markuplint/ml-ast": "3.2.0",
-				"@markuplint/selector": "3.14.0",
-				"@markuplint/shared": "3.8.0",
+				"@markuplint/ml-ast": "4.0.1",
+				"@markuplint/selector": "4.1.1",
+				"@markuplint/shared": "4.0.1",
 				"@types/mustache": "^4.2.5",
 				"deepmerge": "^4.3.1",
 				"is-plain-object": "^5.0.0",
 				"mustache": "^4.2.0",
-				"type-fest": "^4.8.2"
+				"type-fest": "^4.10.2"
 			}
 		},
 		"node_modules/@markuplint/ml-config/node_modules/type-fest": {
@@ -1890,25 +1870,24 @@
 			}
 		},
 		"node_modules/@markuplint/ml-core": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/ml-core/-/ml-core-3.15.0.tgz",
-			"integrity": "sha512-Wm/BfZxSFr8uqcQG6T/qkhvxy3qe0DYejiMoGzJaWMDn1dcH2FqiTuklh/ek49W3o2eTYpkJ+B+0L90zCrmC1w==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@markuplint/ml-core/-/ml-core-4.1.1.tgz",
+			"integrity": "sha512-6LP98wlhyyxGwV+G78/xSzbgDrScVynAupxjigjk2IHEVx1FQ4vtARA42Ie7anmaJX6GbEY3xp/XH7Mh9kULrg==",
 			"dev": true,
 			"dependencies": {
-				"@markuplint/config-presets": "3.9.0",
-				"@markuplint/html-parser": "3.13.0",
-				"@markuplint/html-spec": "3.14.0",
-				"@markuplint/i18n": "3.12.0",
-				"@markuplint/ml-ast": "3.2.0",
-				"@markuplint/ml-config": "3.14.0",
-				"@markuplint/ml-spec": "3.14.0",
-				"@markuplint/parser-utils": "3.13.0",
-				"@markuplint/selector": "3.14.0",
+				"@markuplint/config-presets": "4.1.0",
+				"@markuplint/html-parser": "4.1.1",
+				"@markuplint/html-spec": "4.1.1",
+				"@markuplint/i18n": "4.1.0",
+				"@markuplint/ml-ast": "4.0.1",
+				"@markuplint/ml-config": "4.1.1",
+				"@markuplint/ml-spec": "4.0.2",
+				"@markuplint/parser-utils": "4.1.1",
+				"@markuplint/selector": "4.1.1",
 				"@types/debug": "^4.1.12",
 				"debug": "^4.3.4",
 				"is-plain-object": "^5.0.0",
-				"tslib": "^2.6.2",
-				"type-fest": "^4.8.2"
+				"type-fest": "^4.10.2"
 			}
 		},
 		"node_modules/@markuplint/ml-core/node_modules/type-fest": {
@@ -1924,17 +1903,16 @@
 			}
 		},
 		"node_modules/@markuplint/ml-spec": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/ml-spec/-/ml-spec-3.14.0.tgz",
-			"integrity": "sha512-5swmmXKBxhSlBEUBUh+uYatwEgf2k/9alTGv9Nj0/krlzt8QmhIlJO4COLp7MYg2az+W1iiHO26dXkmBbYZbbg==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@markuplint/ml-spec/-/ml-spec-4.0.2.tgz",
+			"integrity": "sha512-bnuGa0JkRe4CamEmffd0V3uqC6JyNNQ9OKtwWC9O3/nFhf8yvF35cNGRSGjJhgpGVxGHO8o8qApkEuGSec8fyw==",
 			"dev": true,
 			"dependencies": {
-				"@markuplint/ml-ast": "3.2.0",
-				"@markuplint/types": "3.12.0",
+				"@markuplint/ml-ast": "4.0.1",
+				"@markuplint/types": "4.0.2",
 				"dom-accessibility-api": "^0.6.3",
 				"is-plain-object": "^5.0.0",
-				"tslib": "^2.6.2",
-				"type-fest": "^4.8.2"
+				"type-fest": "^4.10.2"
 			}
 		},
 		"node_modules/@markuplint/ml-spec/node_modules/type-fest": {
@@ -1950,17 +1928,48 @@
 			}
 		},
 		"node_modules/@markuplint/parser-utils": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/parser-utils/-/parser-utils-3.13.0.tgz",
-			"integrity": "sha512-XSefmOiWu4tA2Ke+42XF5C5bdgySzm2dq04ja4YUpHmSPwudvzOjYFWGY6+f00jsW1lEU4SYFDxVONq2OBUYjw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@markuplint/parser-utils/-/parser-utils-4.1.1.tgz",
+			"integrity": "sha512-L81RvFn+N/PmdaZ+rOM1C7QkhoCLZpnbHwnPaDQg7vCGiauqIDITEm4c1S5GVw5A257gOeQGcMTjNPopiC8Aog==",
 			"dev": true,
 			"dependencies": {
-				"@markuplint/ml-ast": "3.2.0",
-				"@markuplint/types": "3.12.0",
-				"@types/uuid": "^9.0.7",
-				"tslib": "^2.6.2",
-				"type-fest": "^4.8.2",
+				"@markuplint/ml-ast": "4.0.1",
+				"@markuplint/ml-spec": "4.0.2",
+				"@markuplint/types": "4.0.2",
+				"@types/uuid": "^9.0.8",
+				"debug": "^4.3.4",
+				"espree": "^10.0.1",
+				"type-fest": "^4.10.2",
 				"uuid": "^9.0.1"
+			}
+		},
+		"node_modules/@markuplint/parser-utils/node_modules/eslint-visitor-keys": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.0.0.tgz",
+			"integrity": "sha512-OtIRv/2GyiF6o/d8K7MYKKbXrOUBIK6SfkIRM4Z0dY3w+LiQ0vy3F57m0Z71bjbyeiWFiHJ8brqnmE6H6/jEuw==",
+			"dev": true,
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
+		"node_modules/@markuplint/parser-utils/node_modules/espree": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-10.0.1.tgz",
+			"integrity": "sha512-MWkrWZbJsL2UwnjxTX3gG8FneachS/Mwg7tdGXce011sJd5b0JG54vat5KHnfSBODZ3Wvzd2WnjxyzsRoVv+ww==",
+			"dev": true,
+			"dependencies": {
+				"acorn": "^8.11.3",
+				"acorn-jsx": "^5.3.2",
+				"eslint-visitor-keys": "^4.0.0"
+			},
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@markuplint/parser-utils/node_modules/type-fest": {
@@ -1976,24 +1985,23 @@
 			}
 		},
 		"node_modules/@markuplint/rules": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/rules/-/rules-3.15.0.tgz",
-			"integrity": "sha512-6j8hn9fx91MSZTACOzydBc3FW7XrC2Y+scc3KCnOgKoSupU8Tv4dkIJHe8AQ9fAHDHJv3wJpNZdTtLYakBSoNg==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@markuplint/rules/-/rules-4.1.1.tgz",
+			"integrity": "sha512-eKkf0Qv6dXgyvXYyxvjIiJ7BRl1SZ7hIfGNlchyhDOad2lPBLowlEBnBNIMTQVHDB52wB++CwelGyec6JR+DqA==",
 			"dev": true,
 			"dependencies": {
-				"@markuplint/html-spec": "3.14.0",
-				"@markuplint/ml-core": "3.15.0",
-				"@markuplint/ml-spec": "3.14.0",
-				"@markuplint/selector": "3.14.0",
-				"@markuplint/shared": "3.8.0",
-				"@markuplint/types": "3.12.0",
+				"@markuplint/html-spec": "4.1.1",
+				"@markuplint/ml-core": "4.1.1",
+				"@markuplint/ml-spec": "4.0.2",
+				"@markuplint/selector": "4.1.1",
+				"@markuplint/shared": "4.0.1",
+				"@markuplint/types": "4.0.2",
 				"@types/debug": "^4.1.12",
 				"@ungap/structured-clone": "^1.2.0",
 				"ansi-colors": "^4.1.3",
-				"chrono-node": "^2.7.3",
+				"chrono-node": "^2.7.5",
 				"debug": "^4.3.4",
-				"tslib": "^2.6.2",
-				"type-fest": "^4.8.2"
+				"type-fest": "^4.10.2"
 			}
 		},
 		"node_modules/@markuplint/rules/node_modules/type-fest": {
@@ -2009,17 +2017,16 @@
 			}
 		},
 		"node_modules/@markuplint/selector": {
-			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/selector/-/selector-3.14.0.tgz",
-			"integrity": "sha512-cyJUrHfHG9wRxsBcetY3qkDiKfbXIaA855WbyLS/xhdZ9zPeP5f+y2ho5IZzVJ7yRVAHC+x29DR52kG4PsWGVQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@markuplint/selector/-/selector-4.1.1.tgz",
+			"integrity": "sha512-28Up5dFUepAyDWzM+GJGBVYvTAD5Ia+tgI5bf6JyVzwmKxzFCXGYERcdC8Dwe/Fb5SEOjkp8pI8ivwGI2YKV/Q==",
 			"dev": true,
 			"dependencies": {
-				"@markuplint/ml-spec": "3.14.0",
+				"@markuplint/ml-spec": "4.0.2",
 				"@types/debug": "^4.1.12",
 				"debug": "^4.3.4",
-				"postcss-selector-parser": "^6.0.13",
-				"tslib": "^2.6.2",
-				"type-fest": "^4.8.2"
+				"postcss-selector-parser": "^6.0.15",
+				"type-fest": "^4.10.2"
 			}
 		},
 		"node_modules/@markuplint/selector/node_modules/type-fest": {
@@ -2035,30 +2042,41 @@
 			}
 		},
 		"node_modules/@markuplint/shared": {
-			"version": "3.8.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/shared/-/shared-3.8.0.tgz",
-			"integrity": "sha512-Pw9UiSi5qVsApm6DuMyGRYomAsfTnOH7yz7NT8RzlfObL6i9C3op2c019stw/eBrXRn2w8hsBHOfAfqfgY2jzQ==",
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/@markuplint/shared/-/shared-4.0.1.tgz",
+			"integrity": "sha512-RggPgyahqgunGHa7K5hEFm52+dyjwpgp4YfdNPq7wVhJOu9x/zuVmjzjfyuzdG5zcr68ek8IWh76aaqRYfSwXw==",
 			"dev": true,
 			"dependencies": {
 				"html-entities": "^2.4.0"
 			}
 		},
 		"node_modules/@markuplint/types": {
-			"version": "3.12.0",
-			"resolved": "https://registry.npmjs.org/@markuplint/types/-/types-3.12.0.tgz",
-			"integrity": "sha512-DG8s61lqBmipcqoi/44JSsn9hwOw6yQaIHfeOEtnjqORWhlL38F3sGh6l+hDW9zh5nltibx9o2jZvlT2LheUYA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@markuplint/types/-/types-4.0.2.tgz",
+			"integrity": "sha512-Us/OPFOzqsIWLPY9KVhIYk55INo1k8JYggL/6Hk5XhjEGVKdoR2hfn4iDPnkFS3RrClr3mw9ClNwCozC19KGaA==",
 			"dev": true,
 			"dependencies": {
-				"@types/bcp-47": "1",
-				"@types/css-tree": "^2.3.4",
+				"@types/css-tree": "^2.3.6",
 				"@types/debug": "^4.1.12",
 				"@types/whatwg-mimetype": "3.0.2",
-				"bcp-47": "1",
+				"bcp-47": "^2.1.0",
 				"css-tree": "^2.3.1",
 				"debug": "^4.3.4",
-				"leven": "3",
-				"type-fest": "^4.8.2",
-				"whatwg-mimetype": "^3.0.0"
+				"leven": "^4.0.0",
+				"type-fest": "^4.10.2",
+				"whatwg-mimetype": "^4.0.0"
+			}
+		},
+		"node_modules/@markuplint/types/node_modules/leven": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-4.0.0.tgz",
+			"integrity": "sha512-puehA3YKku3osqPlNuzGDUHq8WpwXupUg1V6NXdV38G+gr+gkBwFC8g1b/+YcIvp8gnqVIus+eJCH/eGsRmJNw==",
+			"dev": true,
+			"engines": {
+				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/@markuplint/types/node_modules/type-fest": {
@@ -2071,15 +2089,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/@markuplint/types/node_modules/whatwg-mimetype": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
-			"integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
 			}
 		},
 		"node_modules/@nodelib/fs.scandir": {
@@ -2389,25 +2398,33 @@
 			"version": "1.0.9",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
 			"integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@tsconfig/node12": {
 			"version": "1.0.11",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
 			"integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@tsconfig/node14": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
 			"integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@tsconfig/node16": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
 			"integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
@@ -2459,12 +2476,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/bcp-47": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/@types/bcp-47/-/bcp-47-1.0.0.tgz",
-			"integrity": "sha512-KNuP/hxVUX2+H5Gps3kCm1QtBWczQ82P2GEK61bcKqk7L0UkXWnsLOBoLm6lwmntnQwcGGSl/V3qwAtQM+aGhg==",
-			"dev": true
-		},
 		"node_modules/@types/body-parser": {
 			"version": "1.19.2",
 			"resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz",
@@ -2474,12 +2485,6 @@
 				"@types/connect": "*",
 				"@types/node": "*"
 			}
-		},
-		"node_modules/@types/cli-color": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/@types/cli-color/-/cli-color-2.0.6.tgz",
-			"integrity": "sha512-uLK0/0dOYdkX8hNsezpYh1gc8eerbhf9bOKZ3e24sP67703mw9S14/yW6mSTatiaKO9v+mU/a1EVy4rOXXeZTA==",
-			"dev": true
 		},
 		"node_modules/@types/compression": {
 			"version": "1.7.5",
@@ -2568,16 +2573,6 @@
 				"@types/node": "*"
 			}
 		},
-		"node_modules/@types/has-yarn": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@types/has-yarn/-/has-yarn-1.0.1.tgz",
-			"integrity": "sha512-dB8hHFvFSjaHxC4vPuJFklbzFHyLECF4sJxahhdaRKN+L/mhxrkOU5Okg1d3Ad4VxNnlVH5kPAvRjTEeR6hDSA==",
-			"deprecated": "This is a stub types definition. has-yarn provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"dependencies": {
-				"has-yarn": "*"
-			}
-		},
 		"node_modules/@types/hast": {
 			"version": "2.3.4",
 			"resolved": "https://registry.npmjs.org/@types/hast/-/hast-2.3.4.tgz",
@@ -2654,16 +2649,6 @@
 				"@types/unist": "*"
 			}
 		},
-		"node_modules/@types/meow": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@types/meow/-/meow-6.0.0.tgz",
-			"integrity": "sha512-RzAdIcBCzg6A61SjQGmQHsJ6nEIsGdd2cAw/MAdBwwI0SZg4iGbtpto44BkY6Vq8SDsiqcCV2DowmHj8v+K1gw==",
-			"deprecated": "This is a stub types definition. meow provides its own type definitions, so you do not need this installed.",
-			"dev": true,
-			"dependencies": {
-				"meow": "*"
-			}
-		},
 		"node_modules/@types/mime": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@types/mime/-/mime-3.0.1.tgz",
@@ -2674,12 +2659,6 @@
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
 			"integrity": "sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==",
-			"dev": true
-		},
-		"node_modules/@types/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==",
 			"dev": true
 		},
 		"node_modules/@types/ms": {
@@ -2719,12 +2698,6 @@
 			"dependencies": {
 				"@types/node": "*"
 			}
-		},
-		"node_modules/@types/normalize-package-data": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
-			"integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
-			"dev": true
 		},
 		"node_modules/@types/parse5": {
 			"version": "6.0.3",
@@ -3147,12 +3120,12 @@
 			"integrity": "sha512-KYHzvsZDJ4c6KUJFh4dYK2qR3pJ0wQoUwxj7Z0eB0XtupULe7o89WkfRITKN01syeZHwRiC0of+T4SzF/WNcVg=="
 		},
 		"node_modules/@w0s/markuplint-config": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@w0s/markuplint-config/-/markuplint-config-2.5.1.tgz",
-			"integrity": "sha512-8a54WHNI+FKEfIm+AFbFINubCPDMt1MgeDL0ZWuyjjwCO3i3/qeNNJQHwqKdJj57QdolGk9DdHZNo4H2lhP8MQ==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@w0s/markuplint-config/-/markuplint-config-3.1.0.tgz",
+			"integrity": "sha512-VuHGKUzZ25rFb0Seqh9X42I0fgZ2hgXa6lAPR8JV3OrMWn+lsnO3AAXSAUZNAY9Ly/eWxvJlcZ8iqdoSy48WOA==",
 			"dev": true,
 			"peerDependencies": {
-				"markuplint": "^3.7.0"
+				"markuplint": "^4.1.1"
 			}
 		},
 		"node_modules/@w0s/paapi-item-image-url-parser": {
@@ -3250,6 +3223,8 @@
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
 			"integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.4.0"
 			}
@@ -3558,15 +3533,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/arrify": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
-			"integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/assert": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/assert/-/assert-2.0.0.tgz",
@@ -3778,14 +3744,14 @@
 			}
 		},
 		"node_modules/bcp-47": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-1.0.8.tgz",
-			"integrity": "sha512-Y9y1QNBBtYtv7hcmoX0tR+tUNSFZGZ6OL6vKPObq8BbOhkCoyayF6ogfLTgAli/KuAEbsYHYUNq2AQuY6IuLag==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/bcp-47/-/bcp-47-2.1.0.tgz",
+			"integrity": "sha512-9IIS3UPrvIa1Ej+lVDdDwO7zLehjqsaByECw0bu2RRGP73jALm6FYbzI5gWbgHLvNdkvfXB5YrSbocZdOS0c0w==",
 			"dev": true,
 			"dependencies": {
-				"is-alphabetical": "^1.0.0",
-				"is-alphanumerical": "^1.0.0",
-				"is-decimal": "^1.0.0"
+				"is-alphabetical": "^2.0.0",
+				"is-alphanumerical": "^2.0.0",
+				"is-decimal": "^2.0.0"
 			},
 			"funding": {
 				"type": "github",
@@ -4291,23 +4257,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/camelcase-keys": {
-			"version": "6.2.2",
-			"resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
-			"integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-			"dev": true,
-			"dependencies": {
-				"camelcase": "^5.3.1",
-				"map-obj": "^4.0.0",
-				"quick-lru": "^4.0.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/caniuse-api": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
@@ -4438,16 +4387,10 @@
 			}
 		},
 		"node_modules/chokidar": {
-			"version": "3.5.3",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-			"integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+			"integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
 			"dev": true,
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://paulmillr.com/funding/"
-				}
-			],
 			"dependencies": {
 				"anymatch": "~3.1.2",
 				"braces": "~3.0.2",
@@ -4459,6 +4402,9 @@
 			},
 			"engines": {
 				"node": ">= 8.10.0"
+			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
 			},
 			"optionalDependencies": {
 				"fsevents": "~2.3.2"
@@ -4912,23 +4858,6 @@
 				}
 			}
 		},
-		"node_modules/cosmiconfig-typescript-loader": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/cosmiconfig-typescript-loader/-/cosmiconfig-typescript-loader-5.0.0.tgz",
-			"integrity": "sha512-+8cK7jRAReYkMwMiG+bxhcNKiHJDM6bR9FD/nGBXOWdMLuYawjF5cGrtLilJ+LGd3ZjCXnJjR5DkfWPoIVlqJA==",
-			"dev": true,
-			"dependencies": {
-				"jiti": "^1.19.1"
-			},
-			"engines": {
-				"node": ">=v16"
-			},
-			"peerDependencies": {
-				"@types/node": "*",
-				"cosmiconfig": ">=8.2",
-				"typescript": ">=4"
-			}
-		},
 		"node_modules/cosmiconfig/node_modules/argparse": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4972,7 +4901,9 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/cross-env": {
 			"version": "7.0.3",
@@ -5282,40 +5213,6 @@
 				"supports-color": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/decamelize": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-			"integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/decamelize-keys": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.1.tgz",
-			"integrity": "sha512-WiPxgEirIV0/eIOMcnFBA3/IJZAZqKnwAwWyvvdi4lsr1WCN22nhdf/3db3DoZcUjTV2SqfzIwNyp6y2xs3nmg==",
-			"dev": true,
-			"dependencies": {
-				"decamelize": "^1.1.0",
-				"map-obj": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/decamelize-keys/node_modules/map-obj": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
-			"integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/decimal.js": {
@@ -6485,18 +6382,6 @@
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
 			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
-		"node_modules/extend-shallow": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-			"dev": true,
-			"dependencies": {
-				"is-extendable": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -6851,6 +6736,20 @@
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
 			"devOptional": true
+		},
+		"node_modules/fsevents": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+			"dev": true,
+			"hasInstallScript": true,
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
 		},
 		"node_modules/function-bind": {
 			"version": "1.1.1",
@@ -7225,30 +7124,6 @@
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true
 		},
-		"node_modules/gray-matter": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-			"integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-			"dev": true,
-			"dependencies": {
-				"js-yaml": "^3.13.1",
-				"kind-of": "^6.0.2",
-				"section-matter": "^1.0.0",
-				"strip-bom-string": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=6.0"
-			}
-		},
-		"node_modules/hard-rejection": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
-			"integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -7553,18 +7428,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/hosted-git-info": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
-			"integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
-			"dev": true,
-			"dependencies": {
-				"lru-cache": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -7798,7 +7661,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
 			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
-			"devOptional": true,
+			"optional": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -7870,9 +7733,9 @@
 			}
 		},
 		"node_modules/is-alphabetical": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
-			"integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+			"integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
 			"dev": true,
 			"funding": {
 				"type": "github",
@@ -7880,13 +7743,13 @@
 			}
 		},
 		"node_modules/is-alphanumerical": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
-			"integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+			"integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
 			"dev": true,
 			"dependencies": {
-				"is-alphabetical": "^1.0.0",
-				"is-decimal": "^1.0.0"
+				"is-alphabetical": "^2.0.0",
+				"is-decimal": "^2.0.0"
 			},
 			"funding": {
 				"type": "github",
@@ -8031,22 +7894,13 @@
 			}
 		},
 		"node_modules/is-decimal": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.4.tgz",
-			"integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+			"integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
 			"dev": true,
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/is-extendable": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-extglob": {
@@ -8203,15 +8057,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-plain-object": {
@@ -9189,6 +9034,8 @@
 			"resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
 			"integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"jiti": "bin/jiti.js"
 			}
@@ -9795,7 +9642,9 @@
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
 			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/make-fetch-happen": {
 			"version": "9.1.0",
@@ -9856,30 +9705,6 @@
 				"tmpl": "1.0.5"
 			}
 		},
-		"node_modules/map-age-cleaner": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
-			"integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-			"dev": true,
-			"dependencies": {
-				"p-defer": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/map-obj": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
-			"integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/markdown-table": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.3.tgz",
@@ -9890,85 +9715,73 @@
 			}
 		},
 		"node_modules/markuplint": {
-			"version": "3.15.0",
-			"resolved": "https://registry.npmjs.org/markuplint/-/markuplint-3.15.0.tgz",
-			"integrity": "sha512-id1RZeZVhVcJCrANtFaEmgbAvJOtHSj9wE9qVB3utP6Sf7u7KGYGLphvGSqdwCcWYbnlvZ0WmJnccJlrH8S6FQ==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/markuplint/-/markuplint-4.1.1.tgz",
+			"integrity": "sha512-Y/0ClnIKx5hOWrYkSlCa4pK6ysPVxWeqoZcWXssvsO1aCdcurXCNe9o3IKYPWDCr/qhMWbSL/HLvskBS4134dg==",
 			"dev": true,
 			"dependencies": {
-				"@markuplint/create-rule-helper": "3.15.0",
-				"@markuplint/file-resolver": "3.15.0",
-				"@markuplint/html-parser": "3.13.0",
-				"@markuplint/html-spec": "3.14.0",
-				"@markuplint/i18n": "3.12.0",
-				"@markuplint/ml-ast": "3.2.0",
-				"@markuplint/ml-config": "3.14.0",
-				"@markuplint/ml-core": "3.15.0",
-				"@markuplint/ml-spec": "3.14.0",
-				"@markuplint/rules": "3.15.0",
-				"@markuplint/shared": "3.8.0",
-				"@types/cli-color": "^2.0.6",
+				"@markuplint/cli-utils": "4.0.1",
+				"@markuplint/file-resolver": "4.1.1",
+				"@markuplint/html-parser": "4.1.1",
+				"@markuplint/html-spec": "4.1.1",
+				"@markuplint/i18n": "4.1.0",
+				"@markuplint/ml-ast": "4.0.1",
+				"@markuplint/ml-config": "4.1.1",
+				"@markuplint/ml-core": "4.1.1",
+				"@markuplint/ml-spec": "4.0.2",
+				"@markuplint/rules": "4.1.1",
+				"@markuplint/shared": "4.0.1",
 				"@types/debug": "^4.1.12",
-				"@types/has-yarn": "^1.0.1",
-				"@types/meow": "^6.0.0",
-				"@types/uuid": "^9.0.7",
-				"chokidar": "^3.5.3",
-				"cli-color": "^2.0.3",
+				"chokidar": "^3.6.0",
 				"debug": "^4.3.4",
-				"detect-installed": "^2.0.4",
-				"eastasianwidth": "^0.2.0",
-				"enquirer": "^2.4.1",
-				"get-stdin": "8",
-				"gray-matter": "^4.0.3",
-				"has-yarn": "2",
-				"meow": "9",
-				"node-fetch": "2",
-				"os-locale": "5",
+				"get-stdin": "^9.0.0",
+				"meow": "^13.2.0",
+				"os-locale": "^6.0.2",
 				"strict-event-emitter": "^0.5.1",
-				"strip-ansi": "6",
-				"tslib": "^2.6.2",
-				"type-fest": "^4.8.2",
-				"uuid": "^9.0.1"
+				"strip-ansi": "^7.1.0",
+				"type-fest": "^4.10.2"
 			},
 			"bin": {
-				"markuplint": "bin/markuplint"
+				"markuplint": "bin/markuplint.mjs"
 			}
 		},
-		"node_modules/markuplint/node_modules/meow": {
+		"node_modules/markuplint/node_modules/ansi-regex": {
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+			"integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-regex?sponsor=1"
+			}
+		},
+		"node_modules/markuplint/node_modules/get-stdin": {
 			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
-			"integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+			"resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-9.0.0.tgz",
+			"integrity": "sha512-dVKBjfWisLAicarI2Sf+JuBE/DghV4UzNAVe9yhEJuzeREd3JhOTE9cUaJTeSa77fsbQUK3pcOpJfM59+VKZaA==",
+			"dev": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/markuplint/node_modules/strip-ansi": {
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
 			"dev": true,
 			"dependencies": {
-				"@types/minimist": "^1.2.0",
-				"camelcase-keys": "^6.2.2",
-				"decamelize": "^1.2.0",
-				"decamelize-keys": "^1.1.0",
-				"hard-rejection": "^2.1.0",
-				"minimist-options": "4.1.0",
-				"normalize-package-data": "^3.0.0",
-				"read-pkg-up": "^7.0.1",
-				"redent": "^3.0.0",
-				"trim-newlines": "^3.0.0",
-				"type-fest": "^0.18.0",
-				"yargs-parser": "^20.2.3"
+				"ansi-regex": "^6.0.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12"
 			},
 			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/markuplint/node_modules/meow/node_modules/type-fest": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
-			"integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-			"dev": true,
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"url": "https://github.com/chalk/strip-ansi?sponsor=1"
 			}
 		},
 		"node_modules/markuplint/node_modules/type-fest": {
@@ -10180,20 +9993,6 @@
 			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mem": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/mem/-/mem-5.1.1.tgz",
-			"integrity": "sha512-qvwipnozMohxLXG1pOqoLiZKNkC4r4qqRucSoDwXowsNGDSULiqFTRUF05vcZWnwJSG22qTsynQhxbaMtnX9gw==",
-			"dev": true,
-			"dependencies": {
-				"map-age-cleaner": "^0.1.3",
-				"mimic-fn": "^2.1.0",
-				"p-is-promise": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/memoizee": {
@@ -10793,15 +10592,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/min-indent": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
-			"integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -10819,20 +10609,6 @@
 			"integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/minimist-options": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
-			"integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-			"dev": true,
-			"dependencies": {
-				"arrify": "^1.0.1",
-				"is-plain-obj": "^1.1.0",
-				"kind-of": "^6.0.3"
-			},
-			"engines": {
-				"node": ">= 6"
 			}
 		},
 		"node_modules/minipass": {
@@ -11132,48 +10908,6 @@
 				"node": "^16 || ^18 || >= 20"
 			}
 		},
-		"node_modules/node-fetch": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-			"integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-			"dev": true,
-			"dependencies": {
-				"whatwg-url": "^5.0.0"
-			},
-			"engines": {
-				"node": "4.x || >=6.0.0"
-			},
-			"peerDependencies": {
-				"encoding": "^0.1.0"
-			},
-			"peerDependenciesMeta": {
-				"encoding": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/node-fetch/node_modules/tr46": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-			"integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-			"dev": true
-		},
-		"node_modules/node-fetch/node_modules/webidl-conversions": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-			"integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-			"dev": true
-		},
-		"node_modules/node-fetch/node_modules/whatwg-url": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-			"integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-			"dev": true,
-			"dependencies": {
-				"tr46": "~0.0.3",
-				"webidl-conversions": "^3.0.0"
-			}
-		},
 		"node_modules/node-gyp": {
 			"version": "8.4.1",
 			"resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-8.4.1.tgz",
@@ -11390,21 +11124,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/normalize-package-data": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
-			"integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
-			"dev": true,
-			"dependencies": {
-				"hosted-git-info": "^4.0.1",
-				"is-core-module": "^2.5.0",
-				"semver": "^7.3.4",
-				"validate-npm-package-license": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/normalize-path": {
@@ -11779,91 +11498,24 @@
 			}
 		},
 		"node_modules/os-locale": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-5.0.0.tgz",
-			"integrity": "sha512-tqZcNEDAIZKBEPnHPlVDvKrp7NzgLi7jRmhKiUoa2NUmhl13FtkAGLUVR+ZsYvApBQdBfYm43A4tXXQ4IrYLBA==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/os-locale/-/os-locale-6.0.2.tgz",
+			"integrity": "sha512-qIb8bzRqaN/vVqEYZ7lTAg6PonskO7xOmM7OClD28F6eFa4s5XGe4bGpHUHMoCHbNNuR0pDYFeSLiW5bnjWXIA==",
 			"dev": true,
 			"dependencies": {
-				"execa": "^4.0.0",
-				"lcid": "^3.0.0",
-				"mem": "^5.0.0"
+				"lcid": "^3.1.1"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": ">=12.20"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/os-locale/node_modules/execa": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-			"integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-			"dev": true,
-			"dependencies": {
-				"cross-spawn": "^7.0.0",
-				"get-stream": "^5.0.0",
-				"human-signals": "^1.1.1",
-				"is-stream": "^2.0.0",
-				"merge-stream": "^2.0.0",
-				"npm-run-path": "^4.0.0",
-				"onetime": "^5.1.0",
-				"signal-exit": "^3.0.2",
-				"strip-final-newline": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/execa?sponsor=1"
-			}
-		},
-		"node_modules/os-locale/node_modules/get-stream": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-			"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-			"dev": true,
-			"dependencies": {
-				"pump": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/os-locale/node_modules/human-signals": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-			"integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8.12.0"
 			}
 		},
 		"node_modules/p-cancelable": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
 			"integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/p-defer": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-			"integrity": "sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/p-is-promise": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
@@ -13184,15 +12836,6 @@
 				}
 			]
 		},
-		"node_modules/quick-lru": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
-			"integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/randombytes": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -13283,120 +12926,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/read-pkg-up": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-			"integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-			"dev": true,
-			"dependencies": {
-				"find-up": "^4.1.0",
-				"read-pkg": "^5.2.0",
-				"type-fest": "^0.8.1"
-			},
-			"engines": {
-				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/find-up": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-			"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-			"dev": true,
-			"dependencies": {
-				"locate-path": "^5.0.0",
-				"path-exists": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/hosted-git-info": {
-			"version": "2.8.9",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-			"dev": true
-		},
-		"node_modules/read-pkg-up/node_modules/locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-			"dev": true,
-			"dependencies": {
-				"p-locate": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/normalize-package-data": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-			"integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
-			"dev": true,
-			"dependencies": {
-				"hosted-git-info": "^2.1.4",
-				"resolve": "^1.10.0",
-				"semver": "2 || 3 || 4 || 5",
-				"validate-npm-package-license": "^3.0.1"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-			"dev": true,
-			"dependencies": {
-				"p-limit": "^2.2.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/read-pkg": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-			"integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
-			"dev": true,
-			"dependencies": {
-				"@types/normalize-package-data": "^2.4.0",
-				"normalize-package-data": "^2.5.0",
-				"parse-json": "^5.0.0",
-				"type-fest": "^0.6.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/read-pkg/node_modules/type-fest": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-			"integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/semver": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-			"integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver"
-			}
-		},
-		"node_modules/read-pkg-up/node_modules/type-fest": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-			"integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/read-pkg/node_modules/hosted-git-info": {
 			"version": "2.8.9",
 			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -13466,19 +12995,6 @@
 			},
 			"engines": {
 				"node": ">=8.10.0"
-			}
-		},
-		"node_modules/redent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
-			"integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-			"dev": true,
-			"dependencies": {
-				"indent-string": "^4.0.0",
-				"strip-indent": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/regexp.prototype.flags": {
@@ -14233,19 +13749,6 @@
 				"node": ">=v12.22.7"
 			}
 		},
-		"node_modules/section-matter": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
-			"integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
-			"dev": true,
-			"dependencies": {
-				"extend-shallow": "^2.0.1",
-				"kind-of": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/secure-keys": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/secure-keys/-/secure-keys-1.0.0.tgz",
@@ -14915,15 +14418,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/strip-bom-string": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
-			"integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/strip-final-newline": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
@@ -14931,18 +14425,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/strip-indent": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
-			"integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
-			"dev": true,
-			"dependencies": {
-				"min-indent": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/strip-json-comments": {
@@ -15699,15 +15181,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/trim-newlines": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
-			"integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/trough": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/trough/-/trough-2.1.0.tgz",
@@ -15750,6 +15223,8 @@
 			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
 			"integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"dependencies": {
 				"@cspotcode/source-map-support": "^0.8.0",
 				"@tsconfig/node10": "^1.0.7",
@@ -15793,6 +15268,8 @@
 			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
 			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=0.3.1"
 			}
@@ -16439,7 +15916,9 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
 			"integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-			"dev": true
+			"dev": true,
+			"optional": true,
+			"peer": true
 		},
 		"node_modules/v8-to-istanbul": {
 			"version": "9.2.0",
@@ -16947,6 +16426,8 @@
 			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
 			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
 			"dev": true,
+			"optional": true,
+			"peer": true,
 			"engines": {
 				"node": ">=6"
 			}

--- a/package.json
+++ b/package.json
@@ -5,18 +5,19 @@
 		"packages/*"
 	],
 	"scripts": {
-		"html-lint-ejs": "markuplint views/*.ejs views/_include/*.ejs",
+		"html-lint": "markuplint packages/backend/.html/**/*.html",
+		"html-lint-ejs": "markuplint views/**/*.ejs",
 		"github-actions-lint": "yamllint .github/workflows/*.yml"
 	},
 	"devDependencies": {
 		"@csstools/postcss-global-data": "^2.1.1",
-		"@markuplint/ejs-parser": "^3.12.0",
+		"@markuplint/ejs-parser": "^4.1.1",
 		"@rollup/plugin-commonjs": "^25.0.7",
 		"@rollup/plugin-node-resolve": "^15.2.3",
 		"@rollup/plugin-terser": "^0.4.4",
 		"@rollup/plugin-typescript": "^11.1.6",
 		"@w0s/eslint-config": "^5.1.0",
-		"@w0s/markuplint-config": "^2.5.1",
+		"@w0s/markuplint-config": "^3.1.0",
 		"@w0s/stylelint-config": "^2.0.1",
 		"@w0s/tsconfig": "^1.4.1",
 		"ajv-cli": "^5.0.0",
@@ -27,7 +28,7 @@
 		"eslint": "^8.56.0",
 		"jest": "^29.7.0",
 		"json-schema-to-typescript": "^13.1.2",
-		"markuplint": "^3.15.0",
+		"markuplint": "^4.1.1",
 		"nodemon": "^3.0.3",
 		"npm-run-all": "^4.1.5",
 		"onchange": "^7.1.0",

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -173,7 +173,7 @@
 										<div class="p-form-grid__contents">
 											<div class="c-form-controls">
 												<span>
-													<input id="fc-relation" class="c-input js-convert-trim" name="relation" value="<%= requestQuery.relation %>" maxlength="23" pattern="[1-9]{1}[0-9]*(,[1-9]{1}[0-9]*)*" style="--inline-size: 15em" />
+													<input id="fc-relation" class="c-input js-convert-trim" name="relation" value="<%= requestQuery.relation %>" maxlength="23" pattern="[1-9]{1}[0-9]*(,[1-9]{1}[0-9]*)*" title="記事 ID のカンマ区切り" style="--inline-size: 15em" />
 													<small>（カンマ区切り）</small>
 												</span>
 											</div>


### PR DESCRIPTION
#361 の対応で v3 系に戻していたが、Markuplint 側での修正対応が行われたので最新バージョンにアップデートする。