### PR TITLE
記事内のブロック引用で `<p>` とそれ以外の要素が混在したときのブロック方向要素間隔のバランスが悪い問題を修正

### DIFF
--- a/packages/frontend/style/object/project/_main-text.css
+++ b/packages/frontend/style/object/project/_main-text.css
@@ -37,14 +37,6 @@
 	border-color: var(--color-green);
 	background: var(--color-white);
 	padding: 1em min(1vw, 1em);
-
-	.p-entry & {
-		padding-block: 0.5em;
-
-		& > p {
-			margin-block: 0.5em;
-		}
-	}
 }
 
 .p-quote__omit {


### PR DESCRIPTION
https://blog.w0s.jp/705#%E7%AB%A3%E5%8A%9F%E5%89%8D%E3%81%AE%E9%81%8B%E8%BB%A2%E5%AE%9F%E7%B8%BE

![引用ブロックの上部空きより下部空きの方が小さい](https://github.com/SaekiTominaga/blog.w0s.jp/assets/4138486/7540c060-fc7e-49df-af2f-256cb7d6f5e1)
