### PR TITLE
`.c-entry-link` の `@media` を `@container` に戻す

### DIFF
--- a/packages/frontend/style/object/component/_grouping.css
+++ b/packages/frontend/style/object/component/_grouping.css
@@ -13,6 +13,7 @@
 
 	display: block flow-root; /* for Safari */
 	contain: layout;
+	container-type: inline-size;
 	line-height: var(--line-height-narrow);
 	font-size: calc(100% * var(--_title-font-expand-ratio));
 
@@ -47,8 +48,7 @@
 	pointer-events: none;
 }
 
-@media (width <= 36em) {
-	/* @container は Chrome で効かない https://github.com/SaekiTominaga/blog.w0s.jp/pull/219 */
+@container (inline-size <= 24em) {
 	.c-entry-link {
 		margin-inline-start: calc(var(--_bullet-inline-size) + var(--_bullet-gap));
 	}


### PR DESCRIPTION
- revert #219
  - 現在の最新環境、および当時の Firefox 110 を VM 環境で確認したが再現しなかった（なぜ?）
- fix  #339