### PR TITLE
Fix css entry link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@rollup/plugin-typescript": "^11.1.6",
 				"@w0s/eslint-config": "^5.1.0",
 				"@w0s/markuplint-config": "^3.1.0",
-				"@w0s/stylelint-config": "^4.0.0",
+				"@w0s/stylelint-config": "^4.1.0",
 				"@w0s/tsconfig": "^1.4.1",
 				"ajv-cli": "^5.0.0",
 				"brotlin": "^1.1.0",
@@ -3153,9 +3153,9 @@
 			"integrity": "sha512-FUv40W7Dotk79VBa8/vQO1aQ3R6YtBQHEZE4lZB/UzM6c7+sdSYsEtCx/NqgU04uXDjIlGYnxfdg1cXtltXytw=="
 		},
 		"node_modules/@w0s/stylelint-config": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@w0s/stylelint-config/-/stylelint-config-4.0.0.tgz",
-			"integrity": "sha512-RtUNh3jTmg62MH8RtTvGC3pnaXjCvYIZCJjvOeQTW22XnZMfO73Hgo3WasHP3mmEOQ30V53iJ1pwOkzTV+EPUg==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/@w0s/stylelint-config/-/stylelint-config-4.1.0.tgz",
+			"integrity": "sha512-vz4LpkHFPvOQg9JzWUeOmgfR1bQhkzKSAWhiSjDmqiSnXIxY6bMs4IfrC/4S0Sf5OBBJtcQxc4PahsctCUni4w==",
 			"dev": true,
 			"dependencies": {
 				"stylelint-config-concentric-order": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
 		"@rollup/plugin-typescript": "^11.1.6",
 		"@w0s/eslint-config": "^5.1.0",
 		"@w0s/markuplint-config": "^3.1.0",
-		"@w0s/stylelint-config": "^4.0.0",
+		"@w0s/stylelint-config": "^4.1.0",
 		"@w0s/tsconfig": "^1.4.1",
 		"ajv-cli": "^5.0.0",
 		"brotlin": "^1.1.0",

--- a/packages/frontend/style/object/component/_grouping.css
+++ b/packages/frontend/style/object/component/_grouping.css
@@ -51,7 +51,7 @@
 	pointer-events: none;
 }
 
-@container (inline-size <= 24em) {
+@container (inline-size <= 40em) {
 	.c-entry-link {
 		margin-inline-start: calc(var(--_bullet-inline-size) + var(--_bullet-gap));
 	}

--- a/packages/frontend/style/object/component/_grouping.css
+++ b/packages/frontend/style/object/component/_grouping.css
@@ -31,10 +31,10 @@
 }
 
 .c-entry-link__thumb {
-	--_margin-inline-end: calc(var(--_gap) + var(--_bullet-inline-size) + var(--_bullet-gap));
-	--_margin-inline-start: 0px;
-	--_margin-block-end: 0px;
 	--_float: inline-start;
+	--_margin-block-end: 0px;
+	--_margin-inline-start: 0px;
+	--_margin-inline-end: calc(var(--_gap) + var(--_bullet-inline-size) + var(--_bullet-gap));
 	--_image-border-width: 1px;
 	--_image-aspect-ratio: 1.5;
 	--_image-inline-size: 180px;
@@ -57,10 +57,10 @@
 	}
 
 	.c-entry-link__thumb {
-		--_margin-block-end: clamp(0px, var(--_image-min-inline-size-px) - var(--_image-min-inline-size-vw), var(--_gap));
-		--_margin-inline-end: 0px;
-		--_margin-inline-start: var(--_gap);
 		--_float: inline-end;
+		--_margin-block-end: clamp(0px, var(--_image-min-inline-size-px) - var(--_image-min-inline-size-vw), var(--_gap));
+		--_margin-inline-start: var(--_gap);
+		--_margin-inline-end: 0px;
 		--_image-inline-size: min(var(--_image-min-inline-size-px), var(--_image-min-inline-size-vw));
 	}
 }

--- a/packages/frontend/style/object/component/_grouping.css
+++ b/packages/frontend/style/object/component/_grouping.css
@@ -13,13 +13,16 @@
 
 	display: block flow-root; /* for Safari */
 	contain: layout;
-	container-type: inline-size;
 	line-height: var(--line-height-narrow);
 	font-size: calc(100% * var(--_title-font-expand-ratio));
 
 	.p-title-list & {
 		--_gap: 25px;
 		--_title-font-expand-ratio: var(--font-ratio-3);
+	}
+
+	*:has(> &) {
+		container-type: inline-size;
 	}
 
 	& > :any-link {

--- a/packages/frontend/style/object/component/_grouping.css
+++ b/packages/frontend/style/object/component/_grouping.css
@@ -34,7 +34,7 @@
 	--_margin-inline-end: calc(var(--_gap) + var(--_bullet-inline-size) + var(--_bullet-gap));
 	--_margin-inline-start: 0px;
 	--_margin-block-end: 0px;
-	--_float: left;
+	--_float: inline-start;
 	--_image-border-width: 1px;
 	--_image-aspect-ratio: 1.5;
 	--_image-inline-size: 180px;
@@ -60,7 +60,7 @@
 		--_margin-block-end: clamp(0px, var(--_image-min-inline-size-px) - var(--_image-min-inline-size-vw), var(--_gap));
 		--_margin-inline-end: 0px;
 		--_margin-inline-start: var(--_gap);
-		--_float: right;
+		--_float: inline-end;
 		--_image-inline-size: min(var(--_image-min-inline-size-px), var(--_image-min-inline-size-vw));
 	}
 }


### PR DESCRIPTION
#368 の関連

記事リンクコンポーネント（`.c-entry-link`）において画面幅 385px〜559px（ブレークポイント直前）の間でビュレットアイコンが消滅していたバグを修正

↓正常
![リンク先頭に△印の緑アイコンが表示](https://github.com/SaekiTominaga/blog.w0s.jp/assets/4138486/c077c318-201d-4b7e-bc08-3fb581f01874)

↓異常
![リンク先頭のアイコンなし](https://github.com/SaekiTominaga/blog.w0s.jp/assets/4138486/47933a5e-80cc-4986-9d1f-b46ec2f0cc0d)

その他、
- `float` の値を倫理プロパティに変更（カスタム変数を使うと Stylelint で検出不能なため気付かなかった）
- 左右切り替えのブレークポイントを変更（従来より広い画面でもサムネイル画像を右側にするようにした）