### PR TITLE
別記事へのリンクでフラグメント付きに対応

### DIFF
--- a/backend/node/src/markdown/lib/Link.ts
+++ b/backend/node/src/markdown/lib/Link.ts
@@ -52,7 +52,7 @@ export default class Link {
 		}
 
 		/* 別記事へのリンク */
-		const entryMatchGroups = mdUrl.match(new RegExp(`^(?<id>${regexp.entryId})$`))?.groups;
+		const entryMatchGroups = mdUrl.match(new RegExp(`^(?<id>${regexp.entryId}(#.+)?)$`))?.groups;
 		if (entryMatchGroups !== undefined) {
 			const { id } = entryMatchGroups;
 


### PR DESCRIPTION
`[リンク](100)` だけでなく `[リンク](100#foo)` にも対応
