### PR TITLE
画像拡大リンクを画像自身からキャプション内に変更

### DIFF
--- a/backend/node/__tests__/MarkdownBlock.test.js
+++ b/backend/node/__tests__/MarkdownBlock.test.js
@@ -921,14 +921,15 @@ describe('Image', () => {
 			`
 <figure>
 	<div class="p-embed">
-		<a href="https://media.w0s.jp/image/blog/file.jpg"
-			><picture
-				><source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=1280;h=960;quality=30 2x" />
-				<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=1280;h=960;quality=30 2x" />
-				<img src="https://media.w0s.jp/thumbimage/blog/file.jpg?type=jpeg;w=640;h=480;quality=60" alt="オリジナル画像" crossorigin="" class="p-embed__image" /></picture
-		></a>
+		<picture
+			><source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=1280;h=960;quality=30 2x" />
+			<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=1280;h=960;quality=30 2x" />
+			<img src="https://media.w0s.jp/thumbimage/blog/file.jpg?type=jpeg;w=640;h=480;quality=60" alt="" crossorigin="" class="p-embed__image"
+		/></picture>
 	</div>
-	<figcaption class="c-caption">title&lt;title> title</figcaption>
+	<figcaption class="c-caption">
+		title&lt;title> title<a href="https://media.w0s.jp/image/blog/file.jpg" class="c-caption__media-expansion"><img src="/image/entry/media-expansion.svg" alt="" width="16" height="16" />オリジナル画像</a>
+	</figcaption>
 </figure>
 `.trim(),
 		);
@@ -1008,14 +1009,15 @@ describe('Image', () => {
 			`
 <figure>
 	<div class="p-embed">
-		<a href="https://media.w0s.jp/image/blog/file.jpg"
-			><picture
-				><source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=1280;h=960;quality=30 2x" />
-				<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=1280;h=960;quality=30 2x" />
-				<img src="https://media.w0s.jp/thumbimage/blog/file.jpg?type=jpeg;w=640;h=480;quality=60" alt="オリジナル画像" crossorigin="" class="p-embed__image" /></picture
-		></a>
+		<picture
+			><source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=1280;h=960;quality=30 2x" />
+			<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=1280;h=960;quality=30 2x" />
+			<img src="https://media.w0s.jp/thumbimage/blog/file.jpg?type=jpeg;w=640;h=480;quality=60" alt="" crossorigin="" class="p-embed__image"
+		/></picture>
 	</div>
-	<figcaption class="c-caption">title&lt;title> <code>code</code></figcaption>
+	<figcaption class="c-caption">
+		title&lt;title> <code>code</code><a href="https://media.w0s.jp/image/blog/file.jpg" class="c-caption__media-expansion"><img src="/image/entry/media-expansion.svg" alt="" width="16" height="16" />オリジナル画像</a>
+	</figcaption>
 </figure>
 `.trim(),
 		);
@@ -1035,14 +1037,15 @@ describe('Image', () => {
 			`
 <figure>
 	<div class="p-embed">
-		<a href="https://media.w0s.jp/image/blog/file.jpg"
-			><picture
-				><source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=1280;h=960;quality=30 2x" />
-				<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=1280;h=960;quality=30 2x" />
-				<img src="https://media.w0s.jp/thumbimage/blog/file.jpg?type=jpeg;w=640;h=480;quality=60" alt="オリジナル画像" crossorigin="" class="p-embed__image" /></picture
-		></a>
+		<picture
+			><source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=1280;h=960;quality=30 2x" />
+			<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=1280;h=960;quality=30 2x" />
+			<img src="https://media.w0s.jp/thumbimage/blog/file.jpg?type=jpeg;w=640;h=480;quality=60" alt="" crossorigin="" class="p-embed__image"
+		/></picture>
 	</div>
-	<figcaption class="c-caption">title&lt;title> title</figcaption>
+	<figcaption class="c-caption">
+		title&lt;title> title<a href="https://media.w0s.jp/image/blog/file.jpg" class="c-caption__media-expansion"><img src="/image/entry/media-expansion.svg" alt="" width="16" height="16" />オリジナル画像</a>
+	</figcaption>
 </figure>
 `.trim(),
 		);
@@ -1062,14 +1065,15 @@ describe('Image', () => {
 			`
 <figure>
 	<div class="p-embed">
-		<a href="https://media.w0s.jp/image/blog/file.jpg"
-			><picture
-				><source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=1280;h=960;quality=30 2x" />
-				<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=1280;h=960;quality=30 2x" />
-				<img src="https://media.w0s.jp/thumbimage/blog/file.jpg?type=jpeg;w=640;h=480;quality=60" alt="オリジナル画像" crossorigin="" class="p-embed__image" /></picture
-		></a>
+		<picture
+			><source type="image/avif" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=avif;w=1280;h=960;quality=30 2x" />
+			<source type="image/webp" srcset="https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=640;h=480;quality=60, https://media.w0s.jp/thumbimage/blog/file.jpg?type=webp;w=1280;h=960;quality=30 2x" />
+			<img src="https://media.w0s.jp/thumbimage/blog/file.jpg?type=jpeg;w=640;h=480;quality=60" alt="" crossorigin="" class="p-embed__image"
+		/></picture>
 	</div>
-	<figcaption class="c-caption">title&lt;title> title</figcaption>
+	<figcaption class="c-caption">
+		title&lt;title> title<a href="https://media.w0s.jp/image/blog/file.jpg" class="c-caption__media-expansion"><img src="/image/entry/media-expansion.svg" alt="" width="16" height="16" />オリジナル画像</a>
+	</figcaption>
 </figure>
 `.trim(),
 		);

--- a/backend/node/src/markdown/toHast/block/embedded.ts
+++ b/backend/node/src/markdown/toHast/block/embedded.ts
@@ -39,67 +39,60 @@ const AMAZON_IMAGE_SIZE = 160;
 export const xEmbeddedMediaToHast = (state: H, node: XEmbeddedMedia): HastElementContent | HastElementContent[] | null | undefined => {
 	const { filename } = node;
 
-	let media: HastElementContent;
-	switch (path.extname(filename)) {
+	const extension = path.extname(filename);
+
+	const media: HastElementContent[] = [];
+	switch (extension) {
 		case '.jpg':
 		case '.jpeg':
 		case '.png': {
-			media = {
+			media.push({
 				type: 'element',
-				tagName: 'a',
-				properties: {
-					href: `https://media.w0s.jp/image/blog/${filename}`,
-				},
+				tagName: 'picture',
 				children: [
 					{
 						type: 'element',
-						tagName: 'picture',
-						children: [
-							{
-								type: 'element',
-								tagName: 'source',
-								properties: {
-									type: 'image/avif',
-									srcset: `https://media.w0s.jp/thumbimage/blog/${filename}?type=avif;w=${String(IMAGE_MAX_SIZE.width)};h=${String(
-										IMAGE_MAX_SIZE.height,
-									)};quality=60, https://media.w0s.jp/thumbimage/blog/${filename}?type=avif;w=${String(IMAGE_MAX_SIZE.width * 2)};h=${String(
-										IMAGE_MAX_SIZE.height * 2,
-									)};quality=30 2x`,
-								},
-								children: [],
-							},
-							{
-								type: 'element',
-								tagName: 'source',
-								properties: {
-									type: 'image/webp',
-									srcset: `https://media.w0s.jp/thumbimage/blog/${filename}?type=webp;w=${String(IMAGE_MAX_SIZE.width)};h=${String(
-										IMAGE_MAX_SIZE.height,
-									)};quality=60, https://media.w0s.jp/thumbimage/blog/${filename}?type=webp;w=${String(IMAGE_MAX_SIZE.width * 2)};h=${String(
-										IMAGE_MAX_SIZE.height * 2,
-									)};quality=30 2x`,
-								},
-								children: [],
-							},
-							{
-								type: 'element',
-								tagName: 'img',
-								properties: {
-									src: `https://media.w0s.jp/thumbimage/blog/${filename}?type=jpeg;w=${String(IMAGE_MAX_SIZE.width)};h=${String(IMAGE_MAX_SIZE.height)};quality=60`,
-									alt: 'オリジナル画像',
-									crossorigin: '',
-									className: ['p-embed__image'],
-								},
-								children: [],
-							},
-						],
+						tagName: 'source',
+						properties: {
+							type: 'image/avif',
+							srcset: `https://media.w0s.jp/thumbimage/blog/${filename}?type=avif;w=${String(IMAGE_MAX_SIZE.width)};h=${String(
+								IMAGE_MAX_SIZE.height,
+							)};quality=60, https://media.w0s.jp/thumbimage/blog/${filename}?type=avif;w=${String(IMAGE_MAX_SIZE.width * 2)};h=${String(
+								IMAGE_MAX_SIZE.height * 2,
+							)};quality=30 2x`,
+						},
+						children: [],
+					},
+					{
+						type: 'element',
+						tagName: 'source',
+						properties: {
+							type: 'image/webp',
+							srcset: `https://media.w0s.jp/thumbimage/blog/${filename}?type=webp;w=${String(IMAGE_MAX_SIZE.width)};h=${String(
+								IMAGE_MAX_SIZE.height,
+							)};quality=60, https://media.w0s.jp/thumbimage/blog/${filename}?type=webp;w=${String(IMAGE_MAX_SIZE.width * 2)};h=${String(
+								IMAGE_MAX_SIZE.height * 2,
+							)};quality=30 2x`,
+						},
+						children: [],
+					},
+					{
+						type: 'element',
+						tagName: 'img',
+						properties: {
+							src: `https://media.w0s.jp/thumbimage/blog/${filename}?type=jpeg;w=${String(IMAGE_MAX_SIZE.width)};h=${String(IMAGE_MAX_SIZE.height)};quality=60`,
+							alt: '',
+							crossorigin: '',
+							className: ['p-embed__image'],
+						},
+						children: [],
 					},
 				],
-			};
+			});
 			break;
 		}
 		case '.svg': {
-			media = {
+			media.push({
 				type: 'element',
 				tagName: 'img',
 				properties: {
@@ -108,11 +101,11 @@ export const xEmbeddedMediaToHast = (state: H, node: XEmbeddedMedia): HastElemen
 					className: ['p-embed__image'],
 				},
 				children: [],
-			};
+			});
 			break;
 		}
 		case '.mp4': {
-			media = {
+			media.push({
 				type: 'element',
 				tagName: 'video',
 				properties: {
@@ -121,14 +114,45 @@ export const xEmbeddedMediaToHast = (state: H, node: XEmbeddedMedia): HastElemen
 					className: ['p-embed__video'],
 				},
 				children: [],
-			};
+			});
 			break;
 		}
 		default:
-			media = {
-				type: 'text',
-				value: '',
-			};
+	}
+
+	const caption: HastElementContent[] = state.all(node);
+	switch (extension) {
+		case '.jpg':
+		case '.jpeg':
+		case '.png': {
+			caption.push({
+				type: 'element',
+				tagName: 'a',
+				properties: {
+					href: `https://media.w0s.jp/image/blog/${filename}`,
+					class: 'c-caption__media-expansion',
+				},
+				children: [
+					{
+						type: 'element',
+						tagName: 'img',
+						properties: {
+							src: '/image/entry/media-expansion.svg',
+							alt: '',
+							width: '16',
+							height: '16',
+						},
+						children: [],
+					},
+					{
+						type: 'text',
+						value: 'オリジナル画像',
+					},
+				],
+			});
+			break;
+		}
+		default:
 	}
 
 	return {
@@ -141,7 +165,7 @@ export const xEmbeddedMediaToHast = (state: H, node: XEmbeddedMedia): HastElemen
 				properties: {
 					className: ['p-embed'],
 				},
-				children: [media],
+				children: media,
 			},
 			{
 				type: 'element',
@@ -149,7 +173,7 @@ export const xEmbeddedMediaToHast = (state: H, node: XEmbeddedMedia): HastElemen
 				properties: {
 					className: ['c-caption'],
 				},
-				children: state.all(node),
+				children: caption,
 			},
 		],
 	};

--- a/frontend/image/image/entry/media-expansion.svg
+++ b/frontend/image/image/entry/media-expansion.svg
@@ -5,7 +5,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 512 512">
 <style type="text/css">
 path {
-	fill: #fff;
+	fill: #666;
 }
 </style>
 

--- a/frontend/style/object/component/_grouping.css
+++ b/frontend/style/object/component/_grouping.css
@@ -137,6 +137,9 @@
 
 /* ===== キャプション ===== */
 .c-caption {
+	display: block flex;
+	flex-wrap: wrap;
+	column-gap: 1.5em;
 	inline-size: fit-content;
 	line-height: var(--line-height-narrow);
 	color: var(--color-gray);
@@ -159,5 +162,27 @@
 	&.-meta {
 		margin-inline-start: auto;
 		padding-inline-start: 10%;
+	}
+}
+
+/* 画像拡大アイコン */
+.c-caption__media-expansion {
+	--_image-size: 0.9lh;
+
+	display: inline flex;
+	column-gap: 0.25em;
+	vertical-align: top;
+
+	& > img {
+		position: relative;
+		transition-duration: 0.05s;
+		transition-property: margin, block-size;
+		margin: calc((1lh - var(--_image-size)) / 2);
+		block-size: var(--_image-size);
+		inline-size: auto;
+	}
+
+	&:hover {
+		--_image-size: 1lh;
 	}
 }

--- a/frontend/style/object/component/_grouping.css
+++ b/frontend/style/object/component/_grouping.css
@@ -167,11 +167,10 @@
 
 /* 画像拡大アイコン */
 .c-caption__media-expansion {
-	--_image-size: 0.9lh;
+	--_image-size: 0.8lh;
 
-	display: inline flex;
+	display: block flex;
 	column-gap: 0.25em;
-	vertical-align: top;
 
 	& > img {
 		position: relative;
@@ -183,6 +182,6 @@
 	}
 
 	&:hover {
-		--_image-size: 1lh;
+		--_image-size: 0.9lh;
 	}
 }

--- a/frontend/style/object/project/_main-embedded.css
+++ b/frontend/style/object/project/_main-embedded.css
@@ -4,31 +4,6 @@
 
 /* ===== 埋め込みコンテンツ（画像、動画、 <iframe> など） ===== */
 .p-embed {
-	contain: layout;
-
-	& > :any-link {
-		--_expand-icon-padding: 4px;
-
-		display: inline flow-root;
-		outline-offset: -1px;
-		outline-width: var(--outline-width-bold);
-
-		&::before {
-			box-sizing: border-box;
-			display: block flow;
-			position: absolute;
-			inset: 1px;
-			background: rgb(0 0 0 / 70%) url("/image/entry/media-expansion.svg") center/contain no-repeat content-box border-box;
-			padding: var(--_expand-icon-padding);
-			block-size: 24px;
-			inline-size: 24px;
-			content: "";
-		}
-
-		&:hover {
-			--_expand-icon-padding: 3px;
-		}
-	}
 }
 
 .p-embed__image,


### PR DESCRIPTION
↓ 変更前
![画像左上に🔎アイコン](https://github.com/SaekiTominaga/blog.w0s.jp/assets/4138486/233fa3da-2e43-4b95-bb14-1845553df0b4)

↓ 変更後
![画像下のキャプション末尾に「オリジナル画像」のテキストリンク（🔎アイコン併記）](https://github.com/SaekiTominaga/blog.w0s.jp/assets/4138486/23b3b6d3-4eae-43a4-a043-1471e6919d4d)
