### PR TITLE
画像拡大リンクの表示バグ修正

### DIFF
--- a/backend/node/__tests__/MarkdownBlock.test.js
+++ b/backend/node/__tests__/MarkdownBlock.test.js
@@ -928,7 +928,7 @@ describe('Image', () => {
 		/></picture>
 	</div>
 	<figcaption class="c-caption">
-		title&lt;title> title<a href="https://media.w0s.jp/image/blog/file.jpg" class="c-caption__media-expansion"><img src="/image/entry/media-expansion.svg" alt="" width="16" height="16" />オリジナル画像</a>
+		<span class="c-caption__text">title&lt;title> title</span><a href="https://media.w0s.jp/image/blog/file.jpg" class="c-caption__media-expansion"><img src="/image/entry/media-expansion.svg" alt="" width="16" height="16" />オリジナル画像</a>
 	</figcaption>
 </figure>
 `.trim(),
@@ -949,7 +949,7 @@ describe('Image', () => {
 			`
 <figure>
 	<div class="p-embed"><img src="https://media.w0s.jp/image/blog/file.svg" alt="" class="p-embed__image" /></div>
-	<figcaption class="c-caption">title&lt;title> title</figcaption>
+	<figcaption class="c-caption"><span class="c-caption__text">title&lt;title> title</span></figcaption>
 </figure>
 `.trim(),
 		);
@@ -969,7 +969,7 @@ describe('Image', () => {
 			`
 <figure>
 	<div class="p-embed"><video src="https://media.w0s.jp/video/blog/file.mp4" controls class="p-embed__video"></video></div>
-	<figcaption class="c-caption">title&lt;title> title</figcaption>
+	<figcaption class="c-caption"><span class="c-caption__text">title&lt;title> title</span></figcaption>
 </figure>
 `.trim(),
 		);
@@ -989,7 +989,7 @@ describe('Image', () => {
 			`
 <figure>
 	<div class="p-embed"></div>
-	<figcaption class="c-caption">title&lt;title> title</figcaption>
+	<figcaption class="c-caption"><span class="c-caption__text">title&lt;title> title</span></figcaption>
 </figure>
 `.trim(),
 		);
@@ -1016,7 +1016,8 @@ describe('Image', () => {
 		/></picture>
 	</div>
 	<figcaption class="c-caption">
-		title&lt;title> <code>code</code><a href="https://media.w0s.jp/image/blog/file.jpg" class="c-caption__media-expansion"><img src="/image/entry/media-expansion.svg" alt="" width="16" height="16" />オリジナル画像</a>
+		<span class="c-caption__text">title&lt;title> <code>code</code></span
+		><a href="https://media.w0s.jp/image/blog/file.jpg" class="c-caption__media-expansion"><img src="/image/entry/media-expansion.svg" alt="" width="16" height="16" />オリジナル画像</a>
 	</figcaption>
 </figure>
 `.trim(),
@@ -1044,7 +1045,7 @@ describe('Image', () => {
 		/></picture>
 	</div>
 	<figcaption class="c-caption">
-		title&lt;title> title<a href="https://media.w0s.jp/image/blog/file.jpg" class="c-caption__media-expansion"><img src="/image/entry/media-expansion.svg" alt="" width="16" height="16" />オリジナル画像</a>
+		<span class="c-caption__text">title&lt;title> title</span><a href="https://media.w0s.jp/image/blog/file.jpg" class="c-caption__media-expansion"><img src="/image/entry/media-expansion.svg" alt="" width="16" height="16" />オリジナル画像</a>
 	</figcaption>
 </figure>
 `.trim(),
@@ -1072,7 +1073,7 @@ describe('Image', () => {
 		/></picture>
 	</div>
 	<figcaption class="c-caption">
-		title&lt;title> title<a href="https://media.w0s.jp/image/blog/file.jpg" class="c-caption__media-expansion"><img src="/image/entry/media-expansion.svg" alt="" width="16" height="16" />オリジナル画像</a>
+		<span class="c-caption__text">title&lt;title> title</span><a href="https://media.w0s.jp/image/blog/file.jpg" class="c-caption__media-expansion"><img src="/image/entry/media-expansion.svg" alt="" width="16" height="16" />オリジナル画像</a>
 	</figcaption>
 </figure>
 `.trim(),

--- a/backend/node/src/markdown/toHast/block/embedded.ts
+++ b/backend/node/src/markdown/toHast/block/embedded.ts
@@ -120,7 +120,16 @@ export const xEmbeddedMediaToHast = (state: H, node: XEmbeddedMedia): HastElemen
 		default:
 	}
 
-	const caption: HastElementContent[] = state.all(node);
+	const caption: HastElementContent[] = [
+		{
+			type: 'element',
+			tagName: 'span',
+			properties: {
+				class: 'c-caption__text',
+			},
+			children: state.all(node),
+		},
+	];
 	switch (extension) {
 		case '.jpg':
 		case '.jpeg':

--- a/frontend/style/object/component/_grouping.css
+++ b/frontend/style/object/component/_grouping.css
@@ -139,7 +139,7 @@
 .c-caption {
 	display: block flex;
 	flex-wrap: wrap;
-	column-gap: 1.5em;
+	gap: 0.5em 1.5em;
 	inline-size: fit-content;
 	line-height: var(--line-height-narrow);
 	color: var(--color-gray);
@@ -163,6 +163,10 @@
 		margin-inline-start: auto;
 		padding-inline-start: 10%;
 	}
+}
+
+/* キャプションテキスト */
+.c-caption__text {
 }
 
 /* 画像拡大アイコン */


### PR DESCRIPTION
#403 のバグ修正

- キャプションテキスト内に `<code>` などのマークアップが存在したときに `gap` が適用されてしまうバグを修正
- 画像拡大リンクが2行目以降に来た場合の上下間隔調整
