### PR TITLE
`prettier.resolveConfig()` に失敗したときにエラーログを出すようにする

### DIFF
--- a/backend/node/src/Controller.ts
+++ b/backend/node/src/Controller.ts
@@ -38,10 +38,13 @@ export default class Controller {
 			httpResponse: HttpResponse;
 		},
 	): Promise<void> {
-		let html = htmlUnformat;
-
 		const prettierOptions = await prettier.resolveConfig(options.filePath, { editorconfig: true });
-		if (prettierOptions !== null) {
+
+		let html: string;
+		if (prettierOptions === null) {
+			this.logger.warn('Failed to resolve prettier config');
+			html = htmlUnformat;
+		} else {
 			html = await prettier.format(htmlUnformat, prettierOptions);
 		}
 


### PR DESCRIPTION
Prettier の設定ファイルの配置を配置していないと人知れずフォーマットが行われない状態になっていた