### PR TITLE
YouTube 埋め込み動画の `end` パラメーター対応

### DIFF
--- a/backend/node/__tests__/MarkdownBlock.test.js
+++ b/backend/node/__tests__/MarkdownBlock.test.js
@@ -1166,7 +1166,7 @@ test('YouTube', async (t) => {
 			await format(
 				await markdown.toHtml(
 					`
-@youtube: 1234567890 title <10>
+@youtube: 1234567890 title <10s>
 `,
 				),
 			),
@@ -1183,19 +1183,42 @@ test('YouTube', async (t) => {
 		);
 	});
 
-	await t.test('size & start', async () => {
+	await t.test('start & end', async () => {
 		const markdown = new Markdown();
 		assert.equal(
 			await format(
 				await markdown.toHtml(
 					`
-@youtube: 1234567890 title <100x150 10>
+@youtube: 1234567890 title <10-20s>
 `,
 				),
 			),
 			`
 <figure>
-	<div class="p-embed"><iframe src="https://www.youtube-nocookie.com/embed/1234567890?cc_load_policy=1&amp;start=10" allow="encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="100" height="150" class="p-embed__frame" style="--aspect-ratio: 100/150"></iframe></div>
+	<div class="p-embed"><iframe src="https://www.youtube-nocookie.com/embed/1234567890?cc_load_policy=1&amp;start=10&amp;end=20" allow="encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="640" height="360" class="p-embed__frame" style="--aspect-ratio: 640/360"></iframe></div>
+	<figcaption class="c-caption">
+		<span class="c-caption__text"
+			><a href="https://www.youtube.com/watch?v=1234567890&amp;t=10s">title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" /></small
+		></span>
+	</figcaption>
+</figure>
+`.trim(),
+		);
+	});
+
+	await t.test('size & start & end', async () => {
+		const markdown = new Markdown();
+		assert.equal(
+			await format(
+				await markdown.toHtml(
+					`
+@youtube: 1234567890 title <100x150 10-20s>
+`,
+				),
+			),
+			`
+<figure>
+	<div class="p-embed"><iframe src="https://www.youtube-nocookie.com/embed/1234567890?cc_load_policy=1&amp;start=10&amp;end=20" allow="encrypted-media;fullscreen;gyroscope;picture-in-picture" title="YouTube 動画" width="100" height="150" class="p-embed__frame" style="--aspect-ratio: 100/150"></iframe></div>
 	<figcaption class="c-caption">
 		<span class="c-caption__text"
 			><a href="https://www.youtube.com/watch?v=1234567890&amp;t=10s">title</a><small class="c-domain"><img src="/image/icon/youtube.svg" alt="(YouTube)" width="16" height="16" /></small

--- a/backend/node/src/markdown/toHast/block/embedded.ts
+++ b/backend/node/src/markdown/toHast/block/embedded.ts
@@ -21,6 +21,7 @@ interface XEmbeddedYouTube {
 	title: string;
 	size: Size | undefined;
 	start: number | undefined;
+	end: number | undefined;
 }
 
 interface XAmazonItem {
@@ -208,12 +209,12 @@ export const xEmbeddedMediaToHast = (state: H, node: XEmbeddedMedia): HastElemen
 };
 
 export const xEmbeddedYouTubeToHast = (_state: H, node: XEmbeddedYouTube): HastElementContent | HastElementContent[] | null | undefined => {
-	const { id, title, size, start } = node;
+	const { id, title, size, start, end } = node;
 
 	const width = size?.width ?? YOUTUBE_BASE_SIZE.width;
 	const height = size?.height ?? YOUTUBE_BASE_SIZE.height;
 
-	const embeddedSearchParams = new URLSearchParams();
+	const embeddedSearchParams = new URLSearchParams(); // https://developers.google.com/youtube/player_parameters?hl=ja#Parameters
 	embeddedSearchParams.set('cc_load_policy', '1');
 
 	const linkSearchParams = new URLSearchParams();
@@ -222,6 +223,10 @@ export const xEmbeddedYouTubeToHast = (_state: H, node: XEmbeddedYouTube): HastE
 	if (start !== undefined && start >= 1) {
 		embeddedSearchParams.set('start', String(start));
 		linkSearchParams.set('t', `${String(start)}s`);
+	}
+
+	if (end !== undefined && end >= 1) {
+		embeddedSearchParams.set('end', String(end));
 	}
 
 	return {

--- a/backend/node/src/markdown/toMdast/block/embedded.ts
+++ b/backend/node/src/markdown/toMdast/block/embedded.ts
@@ -37,6 +37,7 @@ interface XEmbeddedYouTube extends Node {
 	title: string;
 	size: Size | undefined;
 	start: number | undefined;
+	end: number | undefined;
 }
 
 interface XAmazonItem extends Node {
@@ -199,17 +200,25 @@ const toMdast = (): Plugin => {
 
 				let size: Size | undefined;
 				let start: number | undefined;
+				let end: number | undefined;
 				metaOption?.split(META_SEPARATOR).forEach((meta) => {
 					if (/^[1-9][0-9]{2}x[1-9][0-9]{2}$/.test(meta)) {
 						/* 動画サイズ */
-						const [width, height] = meta.split('x');
+						const [metaWidth, metaHeight] = meta.split('x');
+
 						size = {
-							width: Number(width),
-							height: Number(height),
+							width: Number(metaWidth),
+							height: Number(metaHeight),
 						};
-					} else if (/^[1-9][0-9]*$/.test(meta)) {
-						/* 開始位置（秒） */
-						start = Number(meta);
+					} else if (/^[1-9][0-9]*(-[1-9][0-9]*)?s$/.test(meta)) {
+						/* 開始・終了位置（秒） */
+						const [metaStart, metaEnd] = meta.substring(0, meta.length - 1).split('-');
+						console.debug(metaStart, metaEnd);
+
+						start = Number(metaStart);
+						if (metaEnd !== undefined) {
+							end = Number(metaEnd);
+						}
 					}
 				});
 
@@ -219,6 +228,7 @@ const toMdast = (): Plugin => {
 					title: title,
 					size: size,
 					start: start,
+					end: end,
 				};
 				parent.children.splice(index, 1, embedded);
 			}

--- a/views/post.ejs
+++ b/views/post.ejs
@@ -402,7 +402,7 @@
 									<td>画像、動画</td>
 								</tr>
 								<tr>
-									<th scope="row">@youtube:<b class="u-red">␣</b>ID<b class="u-red">␣</b>キャプション<b class="u-red">␣</b>&lt;幅x高さ<b class="u-red">?</b><b class="u-red">␣</b>開始秒<b class="u-red">?</b>&gt;</th>
+									<th scope="row">@youtube:<b class="u-red">␣</b>ID<b class="u-red">␣</b>キャプション<b class="u-red">␣</b>&lt;幅x高さ<b class="u-red">?</b><b class="u-red">␣</b>開始秒(-終了秒<b class="u-red">?</b>)s<b class="u-red">?</b>&gt;</th>
 									<td>YouTube 動画</td>
 								</tr>
 								<tr>


### PR DESCRIPTION
`start` のみの場合も、従来は数字のみ（e.g. `<10>`）だったのを `<10s>` に変更したため、本文データの置換が必要
