### PR TITLE
見出しのセルフリンクのマークアップとスタイルを調整

### DIFF
--- a/backend/node/__tests__/MarkdownBlock.test.js
+++ b/backend/node/__tests__/MarkdownBlock.test.js
@@ -21,10 +21,10 @@ text
 			`
 <p>text</p>
 <section class="p-entry-section -hdg1" id="見出し1">
-	<hgroup>
+	<div class="p-section__hdg">
 		<h2>見出し1</h2>
 		<p class="p-entry-section__self-link"><a href="#%E8%A6%8B%E5%87%BA%E3%81%971" class="c-self-link">§</a></p>
-	</hgroup>
+	</div>
 	<p>text</p>
 </section>
 `.trim(),
@@ -62,24 +62,24 @@ text
 	</li>
 </ol>
 <section class="p-entry-section -hdg1" id="見出し1">
-	<hgroup>
+	<div class="p-section__hdg">
 		<h2>見出し1</h2>
 		<p class="p-entry-section__self-link"><a href="#%E8%A6%8B%E5%87%BA%E3%81%971" class="c-self-link">§</a></p>
-	</hgroup>
+	</div>
 	<p>text</p>
 	<section class="p-entry-section -hdg2" id="見出し2">
-		<hgroup>
+		<div class="p-section__hdg">
 			<h3>見出し2</h3>
 			<p class="p-entry-section__self-link"><a href="#%E8%A6%8B%E5%87%BA%E3%81%972" class="c-self-link">§</a></p>
-		</hgroup>
+		</div>
 		<p>text</p>
 	</section>
 </section>
 <section class="p-entry-section -hdg1" id="見出し1-1">
-	<hgroup>
+	<div class="p-section__hdg">
 		<h2>見出し<em>1</em></h2>
 		<p class="p-entry-section__self-link"><a href="#%E8%A6%8B%E5%87%BA%E3%81%971-1" class="c-self-link">§</a></p>
-	</hgroup>
+	</div>
 	<p>text</p>
 </section>
 `.trim(),

--- a/backend/node/src/markdown/toHast/block/heading.ts
+++ b/backend/node/src/markdown/toHast/block/heading.ts
@@ -37,7 +37,10 @@ export const xHeadingToHast = (state: H, node: XHeading): HastElementContent | H
 
 	return {
 		type: 'element',
-		tagName: 'hgroup',
+		tagName: 'div',
+		properties: {
+			className: ['p-section__hdg'],
+		},
 		children: [
 			heading,
 			{

--- a/frontend/style/object/component/_text.css
+++ b/frontend/style/object/component/_text.css
@@ -29,14 +29,10 @@
 /* ===== セルフリンク <a href="#foo">§</a> ===== */
 .c-self-link {
 	display: inline flex;
-	align-items: center;
 	justify-content: center;
 	outline-width: var(--outline-width-bold);
-	min-block-size: var(--self-link-size);
 	min-inline-size: var(--self-link-size);
 	text-decoration: none;
-	color: var(--link-color);
-	font-size: calc(100% / pow(var(--font-ratio), 3));
 }
 
 /* ===== ボタン ===== */

--- a/frontend/style/object/project/entry/_body.css
+++ b/frontend/style/object/project/entry/_body.css
@@ -48,36 +48,36 @@
 	&.-hdg2 {
 		--_margin-block: calc(var(--stack-margin-base) * 2);
 	}
+}
 
-	& > hgroup {
-		display: block flex;
-		gap: 0.5em;
-		line-height: var(--line-height-narrow);
+.p-section__hdg {
+	display: block flex;
+	gap: 0.5em;
+	align-items: center;
+	line-height: var(--line-height-narrow);
 
-		.p-entry-section.-hdg1 > & {
-			border-block-start: 1px solid transparent;
-			border-block-end: 1px solid var(--color-border-dark);
-			padding-block: 0.25em;
-			font-size: calc(100% * pow(var(--font-ratio), 5));
-		}
+	.p-entry-section.-hdg1 > & {
+		border-block-start: 1px solid transparent;
+		border-block-end: 1px solid var(--color-border-dark);
+		padding-block: 0.25em;
+		font-size: calc(100% * pow(var(--font-ratio), 5));
+	}
 
-		.p-entry-section.-hdg2 > & {
-			font-size: calc(100% * pow(var(--font-ratio), 3));
+	.p-entry-section.-hdg2 > & {
+		font-size: calc(100% * pow(var(--font-ratio), 3));
 
-			&::before {
-				transform: scaleY(80%);
-				border: 0.125em solid var(--color-border-dark);
-				border-radius: var(--border-radius-full);
-				background: var(--color-border-dark); /* for Chrome */
-				content: "";
-			}
+		&::before {
+			transform: scaleY(80%);
+			border: 0.125em solid var(--color-border-dark);
+			border-radius: var(--border-radius-full);
+			background: var(--color-border-dark); /* for Chrome */
+			content: "";
 		}
 	}
 }
 
 .p-entry-section__self-link {
-	display: block flex;
-	align-items: center;
+	font-size: calc(100% / pow(var(--font-ratio), 3));
 }
 
 /* ===== セクション終了 ===== */


### PR DESCRIPTION
- `<hgroup>` の使用を取り止め
- 見た目の変化がない範囲で CSS 調整