### PR TITLE
ページ内リンクの ID プレフィックス機能を削除

### DIFF
--- a/backend/node/src/markdown/config.ts
+++ b/backend/node/src/markdown/config.ts
@@ -1,7 +1,6 @@
 export const config = {
 	lang: 'ja',
 	headingDepthLimit: 2,
-	sectionIdPrefix: 'section-',
 	amazonTrackingId: 'w0s.jp-22',
 	linkHostIcon: [
 		{

--- a/backend/node/src/markdown/lib/Link.ts
+++ b/backend/node/src/markdown/lib/Link.ts
@@ -77,7 +77,7 @@ export default class Link {
 		}
 
 		/* ページ内リンク */
-		const pageLinkMatchGroups = mdUrl.match(new RegExp(`^#(?<id>${config.sectionIdPrefix}.+)`))?.groups;
+		const pageLinkMatchGroups = mdUrl.match(/^#(?<id>.+)/)?.groups;
 		if (pageLinkMatchGroups !== undefined) {
 			const { id } = pageLinkMatchGroups;
 


### PR DESCRIPTION
既に廃止されていたため、記事 HTML 生成時にリンクにならないバグが生じていた。