### PR TITLE
`<th>` であるべき要素の中身が空の場合は `<td>` にする

### DIFF
--- a/backend/node/__tests__/MarkdownBlock.test.js
+++ b/backend/node/__tests__/MarkdownBlock.test.js
@@ -715,6 +715,78 @@ test('table', async (t) => {
 		);
 	});
 
+	await t.test('thead th empty', async () => {
+		const markdown = new Markdown();
+		assert.equal(
+			await format(
+				await markdown.toHtml(
+					`
+| th | |
+| - | - |
+| td | td |
+| td | td |
+`,
+				),
+			),
+			`
+<table class="p-table">
+	<thead>
+		<tr>
+			<th scope="col">th</th>
+			<td></td>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td>td</td>
+			<td>td</td>
+		</tr>
+		<tr>
+			<td>td</td>
+			<td>td</td>
+		</tr>
+	</tbody>
+</table>
+`.trim(),
+		);
+	});
+
+	await t.test('tbody th empty', async () => {
+		const markdown = new Markdown();
+		assert.equal(
+			await format(
+				await markdown.toHtml(
+					`
+| ~ | th |
+| - | - |
+| | td |
+| th | td |
+`,
+				),
+			),
+			`
+<table class="p-table">
+	<thead>
+		<tr>
+			<td></td>
+			<th scope="col">th</th>
+		</tr>
+	</thead>
+	<tbody>
+		<tr>
+			<td></td>
+			<td>td</td>
+		</tr>
+		<tr>
+			<th scope="row">th</th>
+			<td>td</td>
+		</tr>
+	</tbody>
+</table>
+`.trim(),
+		);
+	});
+
 	await t.test('no thead', async () => {
 		const markdown = new Markdown();
 		assert.equal(

--- a/backend/node/src/markdown/toHast/block/table.ts
+++ b/backend/node/src/markdown/toHast/block/table.ts
@@ -1,6 +1,7 @@
 import type { Properties } from 'hast-util-select/lib/types.js';
 import type { Table, TableRow } from 'mdast';
 import type { H } from 'mdast-util-to-hast';
+import { toString } from 'mdast-util-to-string';
 import type { HastElementContent } from 'mdast-util-to-hast/lib/state.js';
 import type { ElementContent } from 'mdast-util-to-hast/lib/handlers/table-row.js';
 
@@ -30,14 +31,16 @@ const tableRowToHast = (state: H, tableRows: TableRow[], table: XTable): HastEle
 				let tagName = 'td';
 				const attributes: Properties = {};
 
-				if (rowIndex === 0) {
-					/* in <thead> */
-					tagName = 'th';
-					attributes['scope'] = 'col';
-				} else if (colIndex === 0 && firstRowHeaderCell) {
-					/* in <tbody> */
-					tagName = 'th';
-					attributes['scope'] = 'row';
+				if (toString(cell) !== '') {
+					if (rowIndex === 0) {
+						/* in <thead> */
+						tagName = 'th';
+						attributes['scope'] = 'col';
+					} else if (colIndex === 0 && firstRowHeaderCell) {
+						/* in <tbody> */
+						tagName = 'th';
+						attributes['scope'] = 'row';
+					}
 				}
 
 				if (alignValue !== null && alignValue !== undefined) {


### PR DESCRIPTION
空の `<th></th>` を避ける