### PR TITLE
`<h3>` 見出し横の縦棒が短く表示されるバグを修正

### DIFF
--- a/frontend/style/object/project/entry/_body.css
+++ b/frontend/style/object/project/entry/_body.css
@@ -53,7 +53,6 @@
 .p-entry-section__hdg {
 	display: block flex;
 	gap: 0.5em;
-	align-items: center;
 	line-height: var(--line-height-narrow);
 
 	.p-entry-section.-hdg1 > & {
@@ -77,6 +76,8 @@
 }
 
 .p-entry-section__self-link {
+	display: block flex;
+	align-items: center;
 	font-size: calc(100% / pow(var(--font-ratio), 3));
 }
 


### PR DESCRIPTION
#422 で発生したバグを元に戻す