### PR TITLE
記事ページの URL 変更の修正漏れ対応

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_entry.md
+++ b/.github/ISSUE_TEMPLATE/1_entry.md
@@ -8,6 +8,6 @@ assignees: SaekiTominaga
 
 ## 記事タイトルまたは URL
 
-https://blog.w0s.jp/XXX
+https://blog.w0s.jp/entry/XXX
 
 ## 内容

--- a/hono/src/markdown/lib/Link.ts
+++ b/hono/src/markdown/lib/Link.ts
@@ -52,13 +52,13 @@ export default class Link {
 		}
 
 		/* 別記事へのリンク */
-		const entryMatchGroups = new RegExp(`^(?<id>${configRemark.regexp.entryId}(#.+)?)$`).exec(mdUrl)?.groups;
+		const entryMatchGroups = new RegExp(`^(?<entryId>${configRemark.regexp.entryId}(#.+)?)$`).exec(mdUrl)?.groups;
 		if (entryMatchGroups !== undefined) {
-			const { id } = entryMatchGroups;
+			const { entryId } = entryMatchGroups;
 
-			if (id !== undefined) {
+			if (entryId !== undefined) {
 				return {
-					href: `/${mdUrl}`,
+					href: `/entry/${mdUrl}`,
 				};
 			}
 		}

--- a/hono/src/markdown/test/phrasing.test.ts
+++ b/hono/src/markdown/test/phrasing.test.ts
@@ -55,7 +55,7 @@ await test('link', async (t) => {
 
 	await t.test('entry ID', async () => {
 		const markdown = new Markdown();
-		assert.equal(await format(await markdown.toHtml('text1[link1](1)text2')), '<p>text1<a href="/1">link1</a>text2</p>'.trim());
+		assert.equal(await format(await markdown.toHtml('text1[link1](1)text2')), '<p>text1<a href="/entry/1">link1</a>text2</p>'.trim());
 	});
 
 	await t.test('amazon', async () => {


### PR DESCRIPTION
#486 での修正漏れ