### PR TITLE
Amazon の商品画像サイズ4桁指定に対応

### DIFF
--- a/hono/src/markdown/toMdast/block/embedded.ts
+++ b/hono/src/markdown/toMdast/block/embedded.ts
@@ -269,7 +269,7 @@ const toMdast = (): Plugin => {
 					let imageId: string | undefined;
 					let imageSize: Size | undefined;
 					metaOption?.split(META_SEPARATOR).forEach((meta) => {
-						if (/^[1-9][0-9]{1,2}x[1-9][0-9]{1,2}$/.test(meta)) {
+						if (/^[1-9][0-9]{1,3}x[1-9][0-9]{1,3}$/.test(meta)) {
 							/* 画像サイズ */
 							const sizes = meta.split('x');
 							imageSize = {


### PR DESCRIPTION
1000px 以上の指定に対応していなかったため、9999px まで許容するようにする