### PR TITLE
Favicon の `link` 要素に `sizes` 属性を追加

### DIFF
--- a/template/admin.ejs
+++ b/template/admin.ejs
@@ -8,8 +8,8 @@
 		<link rel="alternate stylesheet" href="/style/layout_reader.css" title="リーダー表示" />
 		<link rel="stylesheet" href="/style/layout_reader.css" media="print" />
 
-		<link rel="icon" href="/favicon.ico" type="image/svg+xml" />
-		<link rel="alternate icon" href="/favicon.png" type="image/png" />
+		<link rel="icon" href="/favicon.ico" type="image/svg+xml" sizes="any" />
+		<link rel="alternate icon" href="/favicon.png" type="image/png" sizes="32x32" />
 
 		<script src="/script/admin.mjs" type="module"></script>
 

--- a/template/category.ejs
+++ b/template/category.ejs
@@ -10,8 +10,8 @@
 		<link rel="alternate stylesheet" href="/style/layout_reader.css" title="リーダー表示" />
 		<link rel="stylesheet" href="/style/layout_reader.css" media="print" />
 
-		<link rel="icon" href="/favicon.ico" type="image/svg+xml" />
-		<link rel="alternate icon" href="/favicon.png" type="image/png" />
+		<link rel="icon" href="/favicon.ico" type="image/svg+xml" sizes="any" />
+		<link rel="alternate icon" href="/favicon.png" type="image/png" sizes="32x32" />
 
 		<script src="/script/trusted-types.js" defer=""></script>
 		<script src="/script/blog.mjs" type="module"></script>

--- a/template/entry.ejs
+++ b/template/entry.ejs
@@ -10,8 +10,8 @@
 		<link rel="alternate stylesheet" href="/style/layout_reader.css" title="リーダー表示" />
 		<link rel="stylesheet" href="/style/layout_reader.css" media="print" />
 
-		<link rel="icon" href="/favicon.ico" type="image/svg+xml" />
-		<link rel="alternate icon" href="/favicon.png" type="image/png" />
+		<link rel="icon" href="/favicon.ico" type="image/svg+xml" sizes="any" />
+		<link rel="alternate icon" href="/favicon.png" type="image/png" sizes="32x32" />
 
 		<script src="/script/trusted-types.js" defer=""></script>
 		<script src="/script/blog.mjs" type="module"></script>

--- a/template/list.ejs
+++ b/template/list.ejs
@@ -18,8 +18,8 @@
 		<link rel="alternate stylesheet" href="/style/layout_reader.css" title="リーダー表示" />
 		<link rel="stylesheet" href="/style/layout_reader.css" media="print" />
 
-		<link rel="icon" href="/favicon.ico" type="image/svg+xml" />
-		<link rel="alternate icon" href="/favicon.png" type="image/png" />
+		<link rel="icon" href="/favicon.ico" type="image/svg+xml" sizes="any" />
+		<link rel="alternate icon" href="/favicon.png" type="image/png" sizes="32x32" />
 
 		<script src="/script/trusted-types.js" defer=""></script>
 		<script src="/script/blog.mjs" type="module"></script>


### PR DESCRIPTION
Chrome 139 は `sizes` 属性がないと PNG への無駄なリクエストが発生するため。👉[Safari にも実装が入ることだし、あらためて SVG ファビコンのベスト・プラクティスを考えよう 2025 晩夏（実験） / JeffreyFrancesco.org](https://jeffreyfrancesco.org/weblog/2025082901/)