### PR TITLE
[hono] `c.body()` の第一引数を `Buffer<ArrayBuffer>` 型へ変更

### DIFF
--- a/hono/src/app.ts
+++ b/hono/src/app.ts
@@ -89,7 +89,7 @@ app.get('/favicon.ico', async (context, next) => {
 	const file = await fs.promises.readFile(`${config.static.root}/favicon.ico`);
 
 	res.headers.set('Content-Type', 'image/svg+xml;charset=utf-8');
-	context.body(file);
+	context.body(Buffer.from(file));
 
 	await next();
 });


### PR DESCRIPTION
hono@4.9.3 で `Data` の型が変更になるための先行対応