### PR TITLE
フッターのソーシャルメディア画像の下側に不要な余白ができていたバグを修正

### DIFF
--- a/frontend/style/object/project/_footer.css
+++ b/frontend/style/object/project/_footer.css
@@ -43,7 +43,8 @@
 }
 
 .p-footer-social__image {
-	display: inline flow-root;
+	display: inline flex;
+	flex-wrap: nowrap;
 	padding-block-end: 0.5em;
 }
 


### PR DESCRIPTION
#920 の作業ミス