### PR TITLE
Stylelint 17.9.1 にアップデート

### DIFF
--- a/frontend/stylelint.config.js
+++ b/frontend/stylelint.config.js
@@ -2,7 +2,6 @@
 export default {
 	extends: ['@w0s/stylelint-config'],
 	rules: {
-		'selector-no-deprecated': null, // https://github.com/stylelint/stylelint/issues/9221
 		'max-nesting-depth': [
 			5,
 			{

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
 		"globals": "17.5.0",
 		"prettier-plugin-ejs": "1.0.3",
 		"rimraf": "6.1.3",
-		"stylelint": "17.8.0",
+		"stylelint": "17.9.1",
 		"stylelint-attribute-case-sensitivity": "3.0.1",
 		"stylelint-config-concentric-order": "5.5.0",
 		"stylelint-config-standard": "40.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ importers:
         version: 3.13.0(markuplint@4.14.1(typescript@6.0.3))
       '@w0s/stylelint-config':
         specifier: 4.21.0
-        version: 4.21.0(stylelint-attribute-case-sensitivity@3.0.1(stylelint@17.8.0(typescript@6.0.3)))(stylelint-config-concentric-order@5.5.0(stylelint@17.8.0(typescript@6.0.3)))(stylelint-config-standard@40.0.0(stylelint@17.8.0(typescript@6.0.3)))(stylelint-no-default-viewport@2.0.1(stylelint@17.8.0(typescript@6.0.3)))(stylelint-plugin-defensive-css@2.9.1(stylelint@17.8.0(typescript@6.0.3)))(stylelint-plugin-logical-css@2.1.0(stylelint@17.8.0(typescript@6.0.3)))(stylelint-root-colors@3.0.1(stylelint@17.8.0(typescript@6.0.3)))(stylelint@17.8.0(typescript@6.0.3))
+        version: 4.21.0(stylelint-attribute-case-sensitivity@3.0.1(stylelint@17.9.1(typescript@6.0.3)))(stylelint-config-concentric-order@5.5.0(stylelint@17.9.1(typescript@6.0.3)))(stylelint-config-standard@40.0.0(stylelint@17.9.1(typescript@6.0.3)))(stylelint-no-default-viewport@2.0.1(stylelint@17.9.1(typescript@6.0.3)))(stylelint-plugin-defensive-css@2.9.1(stylelint@17.9.1(typescript@6.0.3)))(stylelint-plugin-logical-css@2.1.0(stylelint@17.9.1(typescript@6.0.3)))(stylelint-root-colors@3.0.1(stylelint@17.9.1(typescript@6.0.3)))(stylelint@17.9.1(typescript@6.0.3))
       '@w0s/tsconfig':
         specifier: 3.0.0
         version: 3.0.0(typescript@6.0.3)
@@ -55,29 +55,29 @@ importers:
         specifier: 6.1.3
         version: 6.1.3
       stylelint:
-        specifier: 17.8.0
-        version: 17.8.0(typescript@6.0.3)
+        specifier: 17.9.1
+        version: 17.9.1(typescript@6.0.3)
       stylelint-attribute-case-sensitivity:
         specifier: 3.0.1
-        version: 3.0.1(stylelint@17.8.0(typescript@6.0.3))
+        version: 3.0.1(stylelint@17.9.1(typescript@6.0.3))
       stylelint-config-concentric-order:
         specifier: 5.5.0
-        version: 5.5.0(stylelint@17.8.0(typescript@6.0.3))
+        version: 5.5.0(stylelint@17.9.1(typescript@6.0.3))
       stylelint-config-standard:
         specifier: 40.0.0
-        version: 40.0.0(stylelint@17.8.0(typescript@6.0.3))
+        version: 40.0.0(stylelint@17.9.1(typescript@6.0.3))
       stylelint-no-default-viewport:
         specifier: 2.0.1
-        version: 2.0.1(stylelint@17.8.0(typescript@6.0.3))
+        version: 2.0.1(stylelint@17.9.1(typescript@6.0.3))
       stylelint-plugin-defensive-css:
         specifier: 2.9.1
-        version: 2.9.1(stylelint@17.8.0(typescript@6.0.3))
+        version: 2.9.1(stylelint@17.9.1(typescript@6.0.3))
       stylelint-plugin-logical-css:
         specifier: 2.1.0
-        version: 2.1.0(stylelint@17.8.0(typescript@6.0.3))
+        version: 2.1.0(stylelint@17.9.1(typescript@6.0.3))
       stylelint-root-colors:
         specifier: 3.0.1
-        version: 3.0.1(stylelint@17.8.0(typescript@6.0.3))
+        version: 3.0.1(stylelint@17.9.1(typescript@6.0.3))
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -514,6 +514,13 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
+  '@csstools/css-calc@3.2.0':
+    resolution: {integrity: sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
   '@csstools/css-color-parser@4.0.2':
     resolution: {integrity: sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==}
     engines: {node: '>=20.19.0'}
@@ -527,16 +534,16 @@ packages:
     peerDependencies:
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.1':
-    resolution: {integrity: sha512-BvqN0AMWNAnLk9G8jnUT77D+mUbY/H2b3uDTvg2isJkHaOufUE2R3AOwxWo7VBQKT1lOdwdvorddo2B/lk64+w==}
+  '@csstools/css-syntax-patches-for-csstree@1.1.2':
+    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
     peerDependencies:
       css-tree: ^3.2.1
     peerDependenciesMeta:
       css-tree:
         optional: true
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.2':
-    resolution: {integrity: sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==}
+  '@csstools/css-syntax-patches-for-csstree@1.1.3':
+    resolution: {integrity: sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==}
     peerDependencies:
       css-tree: ^3.2.1
     peerDependenciesMeta:
@@ -3652,8 +3659,8 @@ packages:
     peerDependencies:
       stylelint: ^16.0.0 || ^17.0.0
 
-  stylelint@17.8.0:
-    resolution: {integrity: sha512-oHkld9T60LDSaUQ4CSVc+tlt9eUoDlxhaGWShsUCKyIL14boZfmK5bSphZqx64aiC5tCqX+BsQMTMoSz8D1zIg==}
+  stylelint@17.9.1:
+    resolution: {integrity: sha512-THTmnAPJTrg/JhkTWZlSyrO+HUYMx6ELthIHeMyD2WOKqXIJUFQv2Yxn91bvUrZdbBJaW2dUuQdPST2wcQ6C3g==}
     engines: {node: '>=20.19.0'}
     hasBin: true
 
@@ -4037,6 +4044,11 @@ snapshots:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
+  '@csstools/css-calc@3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
   '@csstools/css-color-parser@4.0.2(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/color-helpers': 6.0.2
@@ -4048,11 +4060,11 @@ snapshots:
     dependencies:
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.1(css-tree@3.2.1)':
+  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
 
-  '@csstools/css-syntax-patches-for-csstree@1.1.2(css-tree@3.2.1)':
+  '@csstools/css-syntax-patches-for-csstree@1.1.3(css-tree@3.2.1)':
     optionalDependencies:
       css-tree: 3.2.1
 
@@ -4555,7 +4567,7 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
       estree-walker: 2.0.2
-      picomatch: 4.0.3
+      picomatch: 4.0.4
     optionalDependencies:
       rollup: 4.60.1
 
@@ -4915,16 +4927,16 @@ snapshots:
 
   '@w0s/string-convert@3.0.3': {}
 
-  '@w0s/stylelint-config@4.21.0(stylelint-attribute-case-sensitivity@3.0.1(stylelint@17.8.0(typescript@6.0.3)))(stylelint-config-concentric-order@5.5.0(stylelint@17.8.0(typescript@6.0.3)))(stylelint-config-standard@40.0.0(stylelint@17.8.0(typescript@6.0.3)))(stylelint-no-default-viewport@2.0.1(stylelint@17.8.0(typescript@6.0.3)))(stylelint-plugin-defensive-css@2.9.1(stylelint@17.8.0(typescript@6.0.3)))(stylelint-plugin-logical-css@2.1.0(stylelint@17.8.0(typescript@6.0.3)))(stylelint-root-colors@3.0.1(stylelint@17.8.0(typescript@6.0.3)))(stylelint@17.8.0(typescript@6.0.3))':
+  '@w0s/stylelint-config@4.21.0(stylelint-attribute-case-sensitivity@3.0.1(stylelint@17.9.1(typescript@6.0.3)))(stylelint-config-concentric-order@5.5.0(stylelint@17.9.1(typescript@6.0.3)))(stylelint-config-standard@40.0.0(stylelint@17.9.1(typescript@6.0.3)))(stylelint-no-default-viewport@2.0.1(stylelint@17.9.1(typescript@6.0.3)))(stylelint-plugin-defensive-css@2.9.1(stylelint@17.9.1(typescript@6.0.3)))(stylelint-plugin-logical-css@2.1.0(stylelint@17.9.1(typescript@6.0.3)))(stylelint-root-colors@3.0.1(stylelint@17.9.1(typescript@6.0.3)))(stylelint@17.9.1(typescript@6.0.3))':
     dependencies:
-      stylelint: 17.8.0(typescript@6.0.3)
-      stylelint-attribute-case-sensitivity: 3.0.1(stylelint@17.8.0(typescript@6.0.3))
-      stylelint-config-concentric-order: 5.5.0(stylelint@17.8.0(typescript@6.0.3))
-      stylelint-config-standard: 40.0.0(stylelint@17.8.0(typescript@6.0.3))
-      stylelint-no-default-viewport: 2.0.1(stylelint@17.8.0(typescript@6.0.3))
-      stylelint-plugin-defensive-css: 2.9.1(stylelint@17.8.0(typescript@6.0.3))
-      stylelint-plugin-logical-css: 2.1.0(stylelint@17.8.0(typescript@6.0.3))
-      stylelint-root-colors: 3.0.1(stylelint@17.8.0(typescript@6.0.3))
+      stylelint: 17.9.1(typescript@6.0.3)
+      stylelint-attribute-case-sensitivity: 3.0.1(stylelint@17.9.1(typescript@6.0.3))
+      stylelint-config-concentric-order: 5.5.0(stylelint@17.9.1(typescript@6.0.3))
+      stylelint-config-standard: 40.0.0(stylelint@17.9.1(typescript@6.0.3))
+      stylelint-no-default-viewport: 2.0.1(stylelint@17.9.1(typescript@6.0.3))
+      stylelint-plugin-defensive-css: 2.9.1(stylelint@17.9.1(typescript@6.0.3))
+      stylelint-plugin-logical-css: 2.1.0(stylelint@17.9.1(typescript@6.0.3))
+      stylelint-root-colors: 3.0.1(stylelint@17.9.1(typescript@6.0.3))
 
   '@w0s/tab@5.0.3': {}
 
@@ -5259,7 +5271,7 @@ snapshots:
   cssstyle@6.2.0:
     dependencies:
       '@asamuzakjp/css-color': 5.0.1
-      '@csstools/css-syntax-patches-for-csstree': 1.1.1(css-tree@3.2.1)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
       css-tree: 3.2.1
       lru-cache: 11.2.7
 
@@ -5855,7 +5867,7 @@ snapshots:
 
   glob@13.0.1:
     dependencies:
-      minimatch: 10.1.2
+      minimatch: 10.2.5
       minipass: 7.1.3
       path-scurry: 2.0.2
 
@@ -7715,53 +7727,53 @@ snapshots:
 
   strip-json-comments@5.0.3: {}
 
-  stylelint-attribute-case-sensitivity@3.0.1(stylelint@17.8.0(typescript@6.0.3)):
+  stylelint-attribute-case-sensitivity@3.0.1(stylelint@17.9.1(typescript@6.0.3)):
     dependencies:
       postcss-selector-parser: 7.1.1
-      stylelint: 17.8.0(typescript@6.0.3)
+      stylelint: 17.9.1(typescript@6.0.3)
 
-  stylelint-config-concentric-order@5.5.0(stylelint@17.8.0(typescript@6.0.3)):
+  stylelint-config-concentric-order@5.5.0(stylelint@17.9.1(typescript@6.0.3)):
     dependencies:
-      stylelint-order: 7.0.1(stylelint@17.8.0(typescript@6.0.3))
+      stylelint-order: 7.0.1(stylelint@17.9.1(typescript@6.0.3))
     transitivePeerDependencies:
       - stylelint
 
-  stylelint-config-recommended@18.0.0(stylelint@17.8.0(typescript@6.0.3)):
+  stylelint-config-recommended@18.0.0(stylelint@17.9.1(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.8.0(typescript@6.0.3)
+      stylelint: 17.9.1(typescript@6.0.3)
 
-  stylelint-config-standard@40.0.0(stylelint@17.8.0(typescript@6.0.3)):
+  stylelint-config-standard@40.0.0(stylelint@17.9.1(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.8.0(typescript@6.0.3)
-      stylelint-config-recommended: 18.0.0(stylelint@17.8.0(typescript@6.0.3))
+      stylelint: 17.9.1(typescript@6.0.3)
+      stylelint-config-recommended: 18.0.0(stylelint@17.9.1(typescript@6.0.3))
 
-  stylelint-no-default-viewport@2.0.1(stylelint@17.8.0(typescript@6.0.3)):
+  stylelint-no-default-viewport@2.0.1(stylelint@17.9.1(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.8.0(typescript@6.0.3)
+      stylelint: 17.9.1(typescript@6.0.3)
 
-  stylelint-order@7.0.1(stylelint@17.8.0(typescript@6.0.3)):
+  stylelint-order@7.0.1(stylelint@17.9.1(typescript@6.0.3)):
     dependencies:
       postcss: 8.5.10
       postcss-sorting: 9.1.0(postcss@8.5.10)
-      stylelint: 17.8.0(typescript@6.0.3)
+      stylelint: 17.9.1(typescript@6.0.3)
 
-  stylelint-plugin-defensive-css@2.9.1(stylelint@17.8.0(typescript@6.0.3)):
+  stylelint-plugin-defensive-css@2.9.1(stylelint@17.9.1(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.8.0(typescript@6.0.3)
+      stylelint: 17.9.1(typescript@6.0.3)
 
-  stylelint-plugin-logical-css@2.1.0(stylelint@17.8.0(typescript@6.0.3)):
+  stylelint-plugin-logical-css@2.1.0(stylelint@17.9.1(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.8.0(typescript@6.0.3)
+      stylelint: 17.9.1(typescript@6.0.3)
 
-  stylelint-root-colors@3.0.1(stylelint@17.8.0(typescript@6.0.3)):
+  stylelint-root-colors@3.0.1(stylelint@17.9.1(typescript@6.0.3)):
     dependencies:
-      stylelint: 17.8.0(typescript@6.0.3)
+      stylelint: 17.9.1(typescript@6.0.3)
 
-  stylelint@17.8.0(typescript@6.0.3):
+  stylelint@17.9.1(typescript@6.0.3):
     dependencies:
-      '@csstools/css-calc': 3.1.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-calc': 3.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-syntax-patches-for-csstree': 1.1.2(css-tree@3.2.1)
+      '@csstools/css-syntax-patches-for-csstree': 1.1.3(css-tree@3.2.1)
       '@csstools/css-tokenizer': 4.0.0
       '@csstools/media-query-list-parser': 5.0.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/selector-resolve-nested': 4.0.0(postcss-selector-parser@7.1.1)
@@ -7857,8 +7869,8 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyglobby@0.2.16:
     dependencies:


### PR DESCRIPTION
selector-no-deprecated の暫定無効化を解除