### PR TITLE
Rollup のビルド過程でエラーメッセージが表示されるバグを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 		"stylelint-no-default-viewport": "2.0.1",
 		"stylelint-plugin-defensive-css": "2.9.1",
 		"stylelint-root-colors": "3.0.1",
+		"tslib": "^2.8.1",
 		"typescript": "6.0.3",
 		"typescript-eslint": "8.59.2"
 	},

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       stylelint-root-colors:
         specifier: 3.0.1
         version: 3.0.1(stylelint@17.10.0(typescript@6.0.3))
+      tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -7835,8 +7838,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tslib@2.8.1:
-    optional: true
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:


### PR DESCRIPTION
```
│ [!] (plugin typescript) RollupError: [plugin typescript] @rollup/plugin-typescript: Could not find module 'tslib', which is required by this plugin. Is it installed
```

tslib をインストールすることで解消