### PR TITLE
複数行の脚注に対応

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
 		"@w0s/base.css": "1.4.0",
 		"@w0s/button-clipboard": "3.0.6",
 		"@w0s/file-size-format": "4.0.0",
-		"@w0s/footnote-reference-popover": "7.3.3",
+		"@w0s/footnote-reference-popover": "7.4.0",
 		"@w0s/form-before-unload-confirm": "3.0.3",
 		"@w0s/form-submit-overlay": "4.0.4",
 		"@w0s/html-escape": "5.0.0",

--- a/frontend/style/object/project/_main-list.css
+++ b/frontend/style/object/project/_main-list.css
@@ -210,6 +210,9 @@
 }
 
 .p-footnote__backref {
-	margin-inline-start: 0.5em;
 	font-size: calc(100% / pow(var(--font-ratio), 2));
+
+	&:not(.p-footnote__content > &) {
+		margin-inline-start: 0.5em;
+	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,8 +97,8 @@ importers:
         specifier: 4.0.0
         version: 4.0.0
       '@w0s/footnote-reference-popover':
-        specifier: 7.3.3
-        version: 7.3.3
+        specifier: 7.4.0
+        version: 7.4.0
       '@w0s/form-before-unload-confirm':
         specifier: 3.0.3
         version: 3.0.3
@@ -1463,8 +1463,8 @@ packages:
     resolution: {integrity: sha512-fHFzzwmAMz1Ap+oISslEkL/7HjudoBS6BQbF+qw764RRpSv0Xyb3XopcwbtiODXz8uYuJ9M28BVBtR/xL6nkKA==}
     engines: {node: '>=22'}
 
-  '@w0s/footnote-reference-popover@7.3.3':
-    resolution: {integrity: sha512-SofeMI7pmdLz20art6a476R8VOni14Ock10LxCvzIXMvwCdcUjtc0DgmMO9VC7a8URWT9xQ2dsH/jEPoAfEBCA==}
+  '@w0s/footnote-reference-popover@7.4.0':
+    resolution: {integrity: sha512-FkF2qce7TDYVjuFx9c08nMo21RDsqqWuH822iSUmG6sYhezEkMgN6T9pJmycV7UpzxcfhPuaHgWRKmu0u+IoHQ==}
 
   '@w0s/form-before-unload-confirm@3.0.3':
     resolution: {integrity: sha512-obw0kmRCWVq9SW8iqZIoln0vGeAEmKSTpYEVVoWjxenKHjTrtS6SX2QsBD0iyFeX49ms3Z4gbnYLpdLSjhKzLg==}
@@ -4907,7 +4907,7 @@ snapshots:
 
   '@w0s/file-size-format@4.0.0': {}
 
-  '@w0s/footnote-reference-popover@7.3.3': {}
+  '@w0s/footnote-reference-popover@7.4.0': {}
 
   '@w0s/form-before-unload-confirm@3.0.3': {}
 

--- a/remark/src/hast/footnote.ts
+++ b/remark/src/hast/footnote.ts
@@ -1,22 +1,45 @@
-import type { ElementContent, Root } from 'hast';
+import type { Root } from 'hast';
 import { select, selectAll } from 'hast-util-select';
 import type { Plugin } from 'unified';
 
 /**
  * 脚注
+ *
+ * <section data-footnotes="" class="footnotes">
+ * 	<h2 class="sr-only" id="footnote-label">Footnotes</h2>
+ * 	<ol>
+ * 		<li id="fn-1">
+ * 			<p>Footnote text. <a href="#fnref-1" data-footnote-backref="" aria-label="Back to reference 1" class="data-footnote-backref">↩</a></p>
+ * 		</li>
+ * 	</ol>
+ * </section>
+ *
+ * ↓
+ *
+ * <section class="p-footnote">
+ * 	<h2 class="p-footnote__hdg">脚注</h2>
+ * 	<ul class="p-footnote__list">
+ * 		<li>
+ * 			<span class="p-footnote__no">1.</span>
+ * 			<div id="fn-1" class="p-footnote__content">
+ * 				<p>Footnote text. <a href="#fnref-1" class="p-footnote__backref">↩ 戻る</a></p>
+ * 			</div>
+ * 		</li>
+ * 	</ul>
+ * </section>
  */
 
 const hast: Plugin<[], Root> = () => {
 	return (tree: Root): void => {
-		const footnote = select('[data-footnotes]', tree);
-		if (footnote === undefined) {
+		const section = select('[data-footnotes]', tree);
+		if (section === undefined) {
 			return;
 		}
-		footnote.properties = {
+		section.properties = {
 			className: ['p-footnote'],
 		};
 
-		const heading = select('#footnote-label', footnote);
+		const heading = select('#footnote-label', section);
 		if (heading !== undefined) {
 			heading.properties = {
 				className: ['p-footnote__hdg'],
@@ -29,81 +52,58 @@ const hast: Plugin<[], Root> = () => {
 			];
 		}
 
-		const list = select(':scope > ol', footnote);
-		if (list === undefined) {
-			return;
+		const list = select(':scope > ol', section);
+		if (list !== undefined) {
+			list.tagName = 'ul';
+			list.properties = {
+				className: ['p-footnote__list'],
+			};
 		}
-		list.tagName = 'ul';
-		list.properties = {
-			className: ['p-footnote__list'],
-		};
 
 		selectAll(':scope > li', list).forEach((listItem, index) => {
-			const { id } = listItem.properties;
+			const { children, properties } = listItem;
+			const { id } = properties;
+
 			listItem.properties = {};
-
-			listItem.children.splice(1, 0, {
-				type: 'element',
-				tagName: 'span',
-				properties: {
-					className: ['p-footnote__no'],
-				},
-				children: [
-					{
-						type: 'text',
-						value: `${String(index + 1)}.`,
-					},
-				],
-			});
-
-			const content = select(':scope > p', listItem);
-			if (content !== undefined) {
-				content.properties = {
-					className: ['p-footnote__content'],
-				};
-
-				const contentChildren: ElementContent[] = [];
-				contentChildren.push({
+			listItem.children = [
+				{
 					type: 'element',
 					tagName: 'span',
 					properties: {
-						id: id,
+						className: ['p-footnote__no'],
 					},
-					children: content.children,
-				});
-				contentChildren.push({
-					type: 'text',
-					value: ' ',
-				});
-
-				const backref = select(':scope > [data-footnote-backref]', content);
-				if (backref !== undefined) {
-					const { href } = backref.properties;
-
-					contentChildren.push({
-						type: 'element',
-						tagName: 'a',
-						properties: {
-							href: href,
-							className: ['p-footnote__backref'],
+					children: [
+						{
+							type: 'text',
+							value: `${String(index + 1)}.`,
 						},
-						children: [
-							{
-								type: 'text',
-								value: '↩ 戻る',
-							},
-						],
-					});
+					],
+				},
+				{
+					type: 'element',
+					tagName: 'div',
+					properties: {
+						id: id,
+						className: ['p-footnote__content'],
+					},
+					children: children,
+				},
+			];
 
-					content.children.splice(content.children.indexOf(backref), 1);
+			const backref = select('[data-footnote-backref]', listItem);
+			if (backref !== undefined) {
+				const { href } = backref.properties;
 
-					const lastChild = content.children.at(-1);
-					if (lastChild?.type === 'text') {
-						lastChild.value = lastChild.value.trim(); // content.children の末尾の [data-footnote-backref] の前にある空白文字を削除する
-					}
-				}
-
-				content.children = contentChildren;
+				backref.properties = {
+					href: href,
+					className: ['p-footnote__backref'],
+				};
+				backref.children = [
+					{
+						type: 'text',
+						value: '↩ 戻る',
+					},
+				];
 			}
 		});
 	};

--- a/remark/src/test/phrasing.test.ts
+++ b/remark/src/test/phrasing.test.ts
@@ -98,7 +98,7 @@ text[^1]text
 				),
 			),
 			`<p>
-	text<span class="c-footnote-ref"><a href="#fn-1" id="fnref-1" class="js-footnote-reference-popover" data-popover-label="脚注" data-popover-class="p-footnote-popover" data-popover-hide-text="閉じる" data-popover-hide-image-src="/image/footnote-popover-close.svg" data-popover-hide-image-width="24" data-popover-hide-image-height="24">[1]</a></span
+	text<span class="c-footnote-ref"><a href="#fn-1" id="fnref-1" class="js-footnote-reference-popover" data-ignore=".p-footnote__backref" data-popover-label="脚注" data-popover-class="p-footnote-popover" data-popover-hide-text="閉じる" data-popover-hide-image-src="/image/footnote-popover-close.svg" data-popover-hide-image-width="24" data-popover-hide-image-height="24">[1]</a></span
 	>text
 </p>
 <section class="p-footnote">
@@ -106,7 +106,9 @@ text[^1]text
 	<ul class="p-footnote__list">
 		<li>
 			<span class="p-footnote__no">1.</span>
-			<p class="p-footnote__content"><span id="fn-1">ref1</span> <a href="#fnref-1" class="p-footnote__backref">↩ 戻る</a></p>
+			<div id="fn-1" class="p-footnote__content">
+				<p>ref1 <a href="#fnref-1" class="p-footnote__backref">↩ 戻る</a></p>
+			</div>
 		</li>
 	</ul>
 </section>`,

--- a/remark/src/toHast/phrasing/footnote.ts
+++ b/remark/src/toHast/phrasing/footnote.ts
@@ -43,6 +43,7 @@ export const footnoteReferenceToHast = (state: State, node: FootnoteReference): 
 					href: `#${clobberPrefix}fn-${safeId}`,
 					id: `${clobberPrefix}fnref-${safeId}${reuseCounter > 1 ? `-${String(reuseCounter)}` : ''}`,
 					className: ['js-footnote-reference-popover'],
+					'data-ignore': '.p-footnote__backref',
 					'data-popover-label': '脚注',
 					'data-popover-class': 'p-footnote-popover',
 					'data-popover-hide-text': '閉じる',


### PR DESCRIPTION
脚注の出力 HTML をカスタマイズするにあたり、これまでは単一行前提としており、複数行の脚注は考慮していなかった。

このたび、以下のような複数行の脚注に対応した。

```markdown
[^1]:
    And that's the footnote.

    That's the second paragraph.
```