### PR TITLE
`table > tbody > th` の背景色を薄くする（`thead` と区別を付ける）

### DIFF
--- a/frontend/style/object/project/_main-tabular.css
+++ b/frontend/style/object/project/_main-tabular.css
@@ -25,7 +25,7 @@
 	}
 
 	& > tbody th {
-		--_bg-color: var(--color-bg-dark);
+		--_bg-color: var(--color-bg-light);
 	}
 
 	& > :is(thead + tbody, tbody + tbody) {


### PR DESCRIPTION
#1008 の置換ミス