### PR TITLE
記事リンクのフォーカス時は下線を消すようにする

### DIFF
--- a/frontend/style/object/component/_grouping.css
+++ b/frontend/style/object/component/_grouping.css
@@ -35,6 +35,10 @@
 
 	& > :any-link {
 		outline: none;
+
+		&:focus {
+			text-decoration-line: none;
+		}
 	}
 }
 


### PR DESCRIPTION
現状はフォーカスリングと相まってごちゃごちゃした印象がある

<img width="1489" height="463" alt="記事リンク（紫色に下線付き）の周りに青い枠線が付いた様子" src="https://github.com/user-attachments/assets/8dfe0fc4-0525-4e7c-8cd8-11977e7e63a2" />