### PR TITLE
iOS Edge の強制ダークテーマ適用時の表示バグ修正

### DIFF
--- a/frontend/style/object/project/_content.css
+++ b/frontend/style/object/project/_content.css
@@ -13,6 +13,7 @@
 		padding: 0.75em 1.5%;
 		text-shadow: 0 0 0.05em oklch(from currentColor l c h / 25%);
 		text-wrap-style: pretty;
+		color: var(--color-black); /* for iOS Edge (Force a dark theme on all websites) */
 		font-size: clamp(calc(100% * pow(var(--font-ratio), 1)), 7svi, calc(100% * pow(var(--font-ratio), 5)));
 	}
 }


### PR DESCRIPTION
背景色が薄いグレーのまま、テキスト色もグレーになってしまう。

<img width="1200" height="900" alt="見出し「「HTML」の記事一覧」のスクショ" src="https://github.com/user-attachments/assets/4ad9dce0-2a6c-408e-b372-af6016e483f8" />
