### PR TITLE
remark の Lint メッセージのマークアップ変更

### DIFF
--- a/frontend/script/unique/preview.test.ts
+++ b/frontend/script/unique/preview.test.ts
@@ -13,12 +13,12 @@ before(() => {
 	<template id="markdown-messages">
 		<tr>
 			<td>
-				<span class="js-icon-info" hidden=""></span>
-				<span class="js-icon-warning" hidden=""></span>
+				<span class="js-info"></span>
+				<span class="js-warning"></span>
 			</td>
 			<td><span class="js-line"></span>:<span class="js-column"></span></td>
 			<td><span class="js-reason"></span></td>
-			<td><a class="js-rule"></a></td>
+			<td><a class="js-rule-id"></a></td>
 		</tr>
 	</template>
 </div>
@@ -133,17 +133,63 @@ await test('messages', async (t) => {
 
 		const parent = messagesTemplate.parentElement!;
 
-		assert.equal(parent.querySelector('tr')?.dataset['level'], 'info');
-		assert.equal(parent.querySelector<HTMLSpanElement>('.js-icon-info')?.hidden, false);
-		assert.equal(parent.querySelector<HTMLSpanElement>('.js-icon-warning')?.hidden, true);
-		assert.equal(parent.querySelector<HTMLSpanElement>('.js-line')?.textContent, '1');
-		assert.equal(parent.querySelector<HTMLSpanElement>('.js-column')?.textContent, '2');
-		assert.equal(parent.querySelector<HTMLSpanElement>('.js-reason')?.textContent, 'Reason');
-		assert.equal(parent.querySelector<HTMLAnchorElement>('.js-rule')?.textContent, 'no-recommended-foo');
-		assert.equal(parent.querySelector<HTMLAnchorElement>('.js-rule')?.href, '');
+		assert.equal(parent.querySelectorAll('tr').length, 1);
+		assert.equal(parent.querySelector<HTMLElement>('.js-info')?.hidden, false);
+		assert.equal(parent.querySelector<HTMLElement>('.js-warning')?.hidden, true);
+		assert.equal(parent.querySelector('.js-line')?.textContent, '1');
+		assert.equal(parent.querySelector('.js-column')?.textContent, '2');
+		assert.equal(parent.querySelector('.js-reason')?.textContent, 'Reason');
+		assert.equal(parent.querySelector('.js-rule-id')?.getAttribute('href'), null);
+		assert.equal(parent.querySelector('.js-rule-id')?.textContent, 'no-recommended-foo');
 	});
 
-	await t.test('warning & URL', async () => {
+	await t.test('warning', async () => {
+		before(() => {
+			// @ts-expect-error: ts(2322)
+			global.fetch = mock.fn(() =>
+				Promise.resolve({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							data: {
+								html: '<p>text</p>',
+								messages: [
+									{
+										line: 1,
+										column: 2,
+										ruleId: 'no-foo',
+										reason: 'Reason',
+									},
+								],
+							},
+						}),
+				}),
+			);
+		});
+
+		const ctrlElement = document.querySelector('textarea')!;
+		const messagesTemplate = document.querySelector<HTMLTemplateElement>('#markdown-messages')!;
+		const previewTemplate = document.querySelector<HTMLTemplateElement>('#message-preview')!;
+
+		await preview({
+			ctrl: ctrlElement,
+			messages: messagesTemplate,
+			preview: previewTemplate,
+		});
+
+		const parent = messagesTemplate.parentElement!;
+
+		assert.equal(parent.querySelectorAll('tr').length, 1);
+		assert.equal(parent.querySelector<HTMLElement>('.js-info')?.hidden, true);
+		assert.equal(parent.querySelector<HTMLElement>('.js-warning')?.hidden, false);
+		assert.equal(parent.querySelector('.js-line')?.textContent, '1');
+		assert.equal(parent.querySelector('.js-column')?.textContent, '2');
+		assert.equal(parent.querySelector('.js-reason')?.textContent, 'Reason');
+		assert.equal(parent.querySelector('.js-rule-id')?.getAttribute('href'), null);
+		assert.equal(parent.querySelector('.js-rule-id')?.textContent, 'no-foo');
+	});
+
+	await t.test('URL', async () => {
 		before(() => {
 			// @ts-expect-error: ts(2322)
 			global.fetch = mock.fn(() =>
@@ -180,13 +226,65 @@ await test('messages', async (t) => {
 
 		const parent = messagesTemplate.parentElement!;
 
-		assert.equal(parent.querySelector('tr')?.dataset['level'], 'warning');
-		assert.equal(parent.querySelector<HTMLSpanElement>('.js-icon-info')?.hidden, true);
-		assert.equal(parent.querySelector<HTMLSpanElement>('.js-icon-warning')?.hidden, false);
-		assert.equal(parent.querySelector<HTMLSpanElement>('.js-line')?.textContent, '1');
-		assert.equal(parent.querySelector<HTMLSpanElement>('.js-column')?.textContent, '2');
-		assert.equal(parent.querySelector<HTMLSpanElement>('.js-reason')?.textContent, 'Reason');
-		assert.equal(parent.querySelector<HTMLAnchorElement>('.js-rule')?.textContent, 'no-foo');
-		assert.equal(parent.querySelector<HTMLAnchorElement>('.js-rule')?.href, 'http://example.com/');
+		assert.equal(parent.querySelector('.js-rule-id')?.getAttribute('href'), 'http://example.com/');
+	});
+
+	await t.test('sort', async () => {
+		before(() => {
+			// @ts-expect-error: ts(2322)
+			global.fetch = mock.fn(() =>
+				Promise.resolve({
+					ok: true,
+					json: () =>
+						Promise.resolve({
+							data: {
+								html: '<p>text</p>',
+								messages: [
+									{
+										line: 2,
+										column: 1,
+										reason: 'Reason1',
+									},
+									{
+										reason: 'Reason2',
+									},
+									{
+										reason: 'Reason3',
+									},
+									{
+										line: 1,
+										column: 2,
+										reason: 'Reason4',
+									},
+								],
+							},
+						}),
+				}),
+			);
+		});
+
+		const ctrlElement = document.querySelector('textarea')!;
+		const messagesTemplate = document.querySelector<HTMLTemplateElement>('#markdown-messages')!;
+		const previewTemplate = document.querySelector<HTMLTemplateElement>('#message-preview')!;
+
+		await preview({
+			ctrl: ctrlElement,
+			messages: messagesTemplate,
+			preview: previewTemplate,
+		});
+
+		const parent = messagesTemplate.parentElement!;
+
+		const trs = parent.querySelectorAll('tr');
+
+		assert.equal(trs.length, 4);
+		assert.equal(trs[0]?.querySelectorAll('td')[1]?.textContent, '1:2');
+		assert.equal(trs[0].querySelectorAll('td')[2]?.textContent, 'Reason4');
+		assert.equal(trs[1]?.querySelectorAll('td')[1]?.textContent, '2:1');
+		assert.equal(trs[1].querySelectorAll('td')[2]?.textContent, 'Reason1');
+		assert.equal(trs[2]?.querySelectorAll('td')[1]?.textContent, ':');
+		assert.equal(trs[2].querySelectorAll('td')[2]?.textContent, 'Reason2');
+		assert.equal(trs[3]?.querySelectorAll('td')[1]?.textContent, ':');
+		assert.equal(trs[3].querySelectorAll('td')[2]?.textContent, 'Reason3');
 	});
 });

--- a/frontend/script/unique/preview.ts
+++ b/frontend/script/unique/preview.ts
@@ -15,8 +15,22 @@ const setMessages = (template: HTMLTemplateElement, messages: readonly Readonly<
 			element.remove();
 		});
 
+	/* 行番号でソート */
+	const sortedMessages = messages.toSorted((a, b) => {
+		if (a.line === undefined && b.line === undefined) {
+			return 0;
+		}
+		if (a.line === undefined) {
+			return 1;
+		}
+		if (b.line === undefined) {
+			return -1;
+		}
+		return a.line - b.line;
+	});
+
 	const fragment = document.createDocumentFragment();
-	messages.forEach((message) => {
+	sortedMessages.forEach((message) => {
 		const clone = template.content.cloneNode(true) as HTMLElement;
 
 		if (message.line !== undefined) {
@@ -38,38 +52,28 @@ const setMessages = (template: HTMLTemplateElement, messages: readonly Readonly<
 			reason.textContent = message.reason;
 		}
 
-		if (message.ruleId !== undefined) {
-			const { ruleId } = message;
+		const { ruleId } = message;
 
-			const info = ruleId.startsWith('no-recommended-');
-			const tr = clone.querySelector('tr');
-			if (info) {
-				if (tr !== null) {
-					tr.dataset['level'] = 'info';
-				}
+		const info = ruleId?.startsWith('no-recommended-') ?? false;
 
-				const icon = clone.querySelector<HTMLElement>('.js-icon-info');
-				if (icon !== null) {
-					icon.hidden = false;
-				}
-			} else {
-				if (tr !== null) {
-					tr.dataset['level'] = 'warning';
-				}
+		const infoIcon = clone.querySelector<HTMLElement>('.js-info');
+		if (infoIcon !== null) {
+			infoIcon.hidden = !info;
+		}
 
-				const icon = clone.querySelector<HTMLElement>('.js-icon-warning');
-				if (icon !== null) {
-					icon.hidden = false;
-				}
+		const warningIcon = clone.querySelector<HTMLElement>('.js-warning');
+		if (warningIcon !== null) {
+			warningIcon.hidden = info;
+		}
+
+		const rule = clone.querySelector<HTMLAnchorElement>('.js-rule-id');
+		if (rule !== null) {
+			if (ruleId !== undefined) {
+				rule.textContent = ruleId;
 			}
 
-			const rule = clone.querySelector<HTMLAnchorElement>('.js-rule');
-			if (rule !== null) {
-				rule.textContent = ruleId;
-
-				if (message.url !== undefined) {
-					rule.href = message.url;
-				}
+			if (message.url !== undefined) {
+				rule.href = message.url;
 			}
 		}
 
@@ -86,9 +90,7 @@ const setMessages = (template: HTMLTemplateElement, messages: readonly Readonly<
  */
 const setPreview = (template: HTMLTemplateElement, html: string): void => {
 	/* いったんクリア */
-	if (template.nextElementSibling !== null) {
-		template.nextElementSibling.remove();
-	}
+	template.nextElementSibling?.remove();
 
 	const fragment = document.createDocumentFragment();
 	const clone = template.content.cloneNode(true) as HTMLElement;

--- a/frontend/style/object/project/_main-admin.css
+++ b/frontend/style/object/project/_main-admin.css
@@ -10,19 +10,20 @@
 }
 
 .p-post-preview__messages {
+	& tr {
+		&:has(.c-form-result-mark.-info:not([hidden])) {
+			background-color: var(--bgcolor-light);
+		}
+
+		&:has(.c-form-result-mark.-warning:not([hidden])) {
+			background-color: var(--bgcolor-lightred);
+		}
+	}
+
 	& th,
 	& td {
-		border: 1px solid var(--border-color-light);
-		background-color: var(--_bg-color);
-		padding: 0.25em 0.5em;
-	}
-
-	& [data-level="info"] {
-		--_bg-color: var(--bgcolor-light);
-	}
-
-	& [data-level="warning"] {
-		--_bg-color: var(--bgcolor-lightred);
+		border: 1px solid var(--border-color-dark);
+		padding: 0.125em 0.5em;
 	}
 }
 

--- a/template/admin.ejs
+++ b/template/admin.ejs
@@ -131,18 +131,12 @@
 														<template id="markdown-messages">
 															<tr>
 																<td class="u-cell -center">
-																	<span class="js-icon-info" hidden="">⚠</span>
-																	<span class="js-icon-warning" hidden="">❌</span>
+																	<span class="c-form-result-mark -info js-info">⚠</span>
+																	<span class="c-form-result-mark -warning js-warning">❌</span>
 																</td>
-																<td>
-																	<pre><code><span class="js-line"></span>:<span class="js-column"></span></code></pre>
-																</td>
-																<td>
-																	<pre><code><span class="js-reason"></span></code></pre>
-																</td>
-																<td>
-																	<pre><code><a class="js-rule"></a></code></pre>
-																</td>
+																<td><span class="js-line"></span>:<span class="js-column"></span></td>
+																<td><span class="js-reason"></span></td>
+																<td><a class="js-rule-id"></a></td>
 															</tr>
 														</template>
 													</tbody>


### PR DESCRIPTION
- `has()` 使用により `<tr>` に `data-level` 属性の設定を取り止め
- メッセージの表示を行番号でソートするように変更