### PR TITLE
ハッシュタグの入力時に # を必須にする

### DIFF
--- a/hono/src/db/Post.ts
+++ b/hono/src/db/Post.ts
@@ -275,10 +275,10 @@ export default class extends Database {
 	 *
 	 * @returns 記事 ID
 	 */
-	async insertSNSQueue(entryId: number, tags: string[] | undefined): Promise<bigint | undefined> {
+	async insertSNSQueue(entryId: number, tags: readonly string[] | undefined): Promise<bigint | undefined> {
 		const query = this.db.insertInto('d_sns_queue').values({
 			entry_id: jsToSQLiteAssignment(entryId),
-			tags: sql`jsonb(${JSON.stringify(tags)})`,
+			tags: sql`jsonb(${JSON.stringify(tags?.map((tag) => tag.trim().replace(/^#/v, '')))})`,
 			mastodon: jsToSQLiteAssignment(false),
 			bluesky: jsToSQLiteAssignment(false),
 			misskey: jsToSQLiteAssignment(false),

--- a/template/admin.ejs
+++ b/template/admin.ejs
@@ -256,7 +256,7 @@
 											<div class="c-form-controls">
 												<label class="c-label -input">
 													<span class="c-label__text">ハッシュタグ</span>
-													<input id="fc-social-tag" class="c-input js-convert-trim" name="social_tag" value="<%= entryData.socialTags?.join(',') %>" maxlength="100" style="--inline-size: 15em" disabled="" />
+													<input id="fc-social-tag" class="c-input js-convert-trim" name="social_tag" value="<%= entryData.socialTags?.join(',') %>" maxlength="100" pattern="#[^ ]+(, ?#[^ ]+)*" title="ハッシュタグのカンマ区切り" style="--inline-size: 15em" disabled="" />
 													<small>（カンマ区切り）</small>
 												</label>
 											</div>


### PR DESCRIPTION
関連記事の情報をハッシュタグ欄に入力してしまう事象があったので、ハッシュタグのフォーマットを厳しくすることで誤入力を防止する。