### PR TITLE
Markdown 処理に際して改行コードを LF に統一する

### DIFF
--- a/remark/src/Markdown.ts
+++ b/remark/src/Markdown.ts
@@ -233,6 +233,8 @@ export default class Markdown {
 	 * @returns HTML
 	 */
 	async toHtml(markdown: string): Promise<VFile> {
-		return this.#remark.process(markdown);
+		const markdownLineBreakConverted = markdown.replaceAll(`\r\n`, '\n'); // プレビューでは LF、DB 格納データは CRLF なので統一する
+
+		return this.#remark.process(markdownLineBreakConverted);
 	}
 }


### PR DESCRIPTION
プレビュー時と DB 格納データで改行コードが異なるため、`=== '\n'` での判定を行っている箇所がプレビューと test では想定通りになるものの、実際の HTML ファイル生成時には正しく判定されていなかった。

具体的には #1003 の改修以降、「リンク」が単なる段落（クラス名なしの `<p>`）になってしまっていた。