### PR TITLE
CSP の `form-action` ディレクティブにサイト内検索の各検索エンジンを追加

### DIFF
--- a/hono/src/app.test.ts
+++ b/hono/src/app.test.ts
@@ -9,7 +9,7 @@ await test('headers', async () => {
 	assert.equal(res.headers.get('Strict-Transport-Security'), 'max-age=31536000');
 	assert.equal(
 		res.headers.get('Content-Security-Policy'),
-		"base-uri 'none';form-action 'self';frame-ancestors 'self';report-uri https://report.w0s.jp/report/csp;report-to default",
+		"base-uri 'none';form-action 'self' https://www.google.com https://www.bing.com https://search.yahoo.co.jp https://duckduckgo.com;frame-ancestors 'self';report-uri https://report.w0s.jp/report/csp;report-to default",
 	);
 	assert.equal(res.headers.get('Reporting-Endpoints'), 'default="https://report.w0s.jp/report/csp"');
 	assert.equal(res.headers.get('X-Content-Type-Options'), 'nosniff');

--- a/hono/src/config/hono.ts
+++ b/hono/src/config/hono.ts
@@ -69,7 +69,7 @@ const config: HonoConfig = {
 			},
 			cspHtml: {
 				'base-uri': ["'none'"],
-				'form-action': ["'self'"],
+				'form-action': ["'self'", 'https://www.google.com', 'https://www.bing.com', 'https://search.yahoo.co.jp', 'https://duckduckgo.com'],
 				'frame-ancestors': ["'self'"],
 				'report-uri': ['https://report.w0s.jp/report/csp'],
 				'report-to': ['default'],


### PR DESCRIPTION
#1053 でフォーム送信後に各検索エンジンへリダイレクトするようにしたが、Chrome 系ブラウザはリダイレクトでも CSP チェックに引っ掛かる。👉https://github.com/w3c/webappsec-csp/issues/8