### PR TITLE
Basic 認証改修

### DIFF
--- a/hono/src/app.ts
+++ b/hono/src/app.ts
@@ -40,13 +40,18 @@ app.use(async (context, next) => {
 });
 
 /* Auth */
-const basicAuthHandler = await basicAuth({
-	authPath: `${env('ROOT')}/${env('AUTH_DIR')}/${env('AUTH_ADMIN')}`,
-	invalidUserMessage: config.basicAuth.unauthorizedMessage,
-});
-app.use(`/admin/*`, basicAuthHandler);
-app.use(`/${config.api.dir}/clear`, basicAuthHandler);
-app.use(`/${config.api.dir}/media`, basicAuthHandler);
+await Promise.all(
+	config.basicAuth.map(async ({ paths, realm, env: envKey }) => {
+		const basicAuthHandler = await basicAuth({
+			authFilePath: `${env('ROOT')}/${env('AUTH_DIR')}/${env(envKey)}`,
+			realm: realm,
+		});
+
+		paths.forEach((routingPath) => {
+			app.use(routingPath, basicAuthHandler);
+		});
+	}),
+);
 
 /* Compress */
 app.use(

--- a/hono/src/config/hono.ts
+++ b/hono/src/config/hono.ts
@@ -32,8 +32,10 @@ interface HonoConfig {
 		};
 	};
 	basicAuth: {
-		unauthorizedMessage: string;
-	};
+		paths: string[];
+		realm: string;
+		env: string;
+	}[];
 	cacheControl: string;
 	errorpage: {
 		unauthorized: string;
@@ -152,9 +154,13 @@ const config: HonoConfig = {
 			sourceMap: ['.js', '.mjs'],
 		},
 	},
-	basicAuth: {
-		unauthorizedMessage: 'Unauthorized',
-	},
+	basicAuth: [
+		{
+			paths: ['/admin/*', '/api/clear', '/api/media'],
+			realm: 'Admin',
+			env: 'AUTH_FILE_ADMIN',
+		},
+	],
 	cacheControl: 'max-age=600',
 	errorpage: {
 		unauthorized: '401.html', // 401

--- a/hono/src/controller/admin.test.ts
+++ b/hono/src/controller/admin.test.ts
@@ -2,10 +2,10 @@ import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
 import { env } from '@w0s/env-value-type';
 import app from '../app.ts';
-import { getAuth } from '../util/auth.ts';
+import { getAuthFile } from '../util/auth.ts';
 
-const auth = await getAuth(`${env('ROOT')}/${env('AUTH_DIR')}/${env('AUTH_ADMIN')}`);
-const authorization = `Basic ${Buffer.from(`${auth.user}:${auth.password_orig!}`).toString('base64')}`;
+const auth = (await getAuthFile(`${env('ROOT')}/${env('AUTH_DIR')}/${env('AUTH_FILE_ADMIN')}`)).at(0);
+const authorization = `Basic ${Buffer.from(`${String(auth?.username)}:${String(auth?.password.orig)}`).toString('base64')}`;
 
 await test('no param', async () => {
 	const res = await app.request('/admin/', {

--- a/hono/src/controller/api/clear.test.ts
+++ b/hono/src/controller/api/clear.test.ts
@@ -3,11 +3,11 @@ import { test } from 'node:test';
 import { env } from '@w0s/env-value-type';
 import app from '../../app.ts';
 import PostDao from '../../db/Post.ts';
-import { getAuth } from '../../util/auth.ts';
+import { getAuthFile } from '../../util/auth.ts';
 import type { Post } from '../../../../@types/api.d.ts';
 
-const auth = await getAuth(`${env('ROOT')}/${env('AUTH_DIR')}/${env('AUTH_ADMIN')}`);
-const authorization = `Basic ${Buffer.from(`${auth.user}:${auth.password_orig!}`).toString('base64')}`;
+const auth = (await getAuthFile(`${env('ROOT')}/${env('AUTH_DIR')}/${env('AUTH_FILE_ADMIN')}`)).at(0);
+const authorization = `Basic ${Buffer.from(`${String(auth?.username)}:${String(auth?.password.orig)}`).toString('base64')}`;
 
 await test('GET', async () => {
 	const res = await app.request('/api/clear', {

--- a/hono/src/controller/api/mediaUpload.test.ts
+++ b/hono/src/controller/api/mediaUpload.test.ts
@@ -5,11 +5,11 @@ import sharp from 'sharp';
 import { env } from '@w0s/env-value-type';
 import app from '../../app.ts';
 import configProcess from '../../config/process.ts';
-import { getAuth } from '../../util/auth.ts';
+import { getAuthFile } from '../../util/auth.ts';
 import type { MediaUpload } from '../../../../@types/api.d.ts';
 
-const auth = await getAuth(`${env('ROOT')}/${env('AUTH_DIR')}/${env('AUTH_ADMIN')}`);
-const authorization = `Basic ${Buffer.from(`${auth.user}:${auth.password_orig!}`).toString('base64')}`;
+const auth = (await getAuthFile(`${env('ROOT')}/${env('AUTH_DIR')}/${env('AUTH_FILE_ADMIN')}`)).at(0);
+const authorization = `Basic ${Buffer.from(`${String(auth?.username)}:${String(auth?.password.orig)}`).toString('base64')}`;
 
 await test('GET', async () => {
 	const res = await app.request('/api/clear', {

--- a/hono/src/util/auth.ts
+++ b/hono/src/util/auth.ts
@@ -1,47 +1,74 @@
 import crypto from 'node:crypto';
+import { promisify } from 'node:util';
 import fs from 'node:fs';
 import { basicAuth as basicAuthHono } from 'hono/basic-auth';
 import type { MiddlewareHandler } from 'hono/types';
 
 interface Auth {
-	user: string;
-	password: string;
-	password_orig?: string;
-	realm: string;
+	username: string;
+	password: {
+		salt: string;
+		hash: string;
+		orig?: string;
+	};
 }
 
-/**
- * 認証ファイルを読み取る
- *
- * @param authPath - 認証ファイル（JSON）のパス
- *
- * @returns 認証ファイルの内容
- */
-export const getAuth = async (authPath: string): Promise<Auth> => JSON.parse((await fs.promises.readFile(authPath)).toString()) as Readonly<Auth>;
+const scrypt = promisify(crypto.scrypt);
+
+const verifyPassword = async (
+	password: string,
+	stored: {
+		saltBase64: string;
+		hashBase64: string;
+	},
+): Promise<boolean> => {
+	const salt = Buffer.from(stored.saltBase64, 'base64');
+	const storedHash = Buffer.from(stored.hashBase64, 'base64');
+
+	const hash = (await scrypt(password, salt, storedHash.length)) as Buffer;
+
+	return crypto.timingSafeEqual(hash, storedHash);
+};
 
 /**
  * 認証ファイルを読み取る
  *
+ * @param authFilePath - 認証ファイル（JSON）のパス
+ *
+ * @returns 認証データ
+ */
+export const getAuthFile = async (authFilePath: string): Promise<Auth[]> => JSON.parse((await fs.promises.readFile(authFilePath)).toString()) as Auth[];
+
+/**
+ * 認証
+ *
  * @param options - オプション
- * @param options.authPath - 認証ファイル（JSON）のパス
- * @param options.unauthorizedMessage - ユーザー名が無効な場合のカスタム メッセージ
+ * @param options.authFilePath - 認証ファイル（JSON）のパス
+ * @param options.realm - realm 値
  *
  * @returns 認証ファイルの内容
  */
 export const basicAuth = async (
 	options: Readonly<{
-		authPath: string;
-		invalidUserMessage: string;
+		authFilePath: string;
+		realm: string;
 	}>,
 ): Promise<MiddlewareHandler> => {
-	const auth = await getAuth(options.authPath);
+	const credentials = await getAuthFile(options.authFilePath);
 
 	return basicAuthHono({
 		verifyUser: (username, password) => {
-			const passwordHash = crypto.hash('sha256', password);
-			return username === auth.user && passwordHash === auth.password;
+			const matchCredential = credentials.find((credential) => username === credential.username);
+
+			if (matchCredential === undefined) {
+				return false;
+			}
+
+			return verifyPassword(password, {
+				saltBase64: matchCredential.password.salt,
+				hashBase64: matchCredential.password.hash,
+			});
 		},
-		realm: auth.realm,
-		invalidUserMessage: options.invalidUserMessage,
+		realm: options.realm,
 	});
 };


### PR DESCRIPTION
- ソルト付き対応
- ハッシュ生成を scrypt に変更
- JSON 形式変更
  - 1ファイルに複数の認証情報を格納できるよう配列形式に変更
  - password の中身をソルト、ハッシュ等で構造化できるように boject 型に変更