### PR TITLE
脚注 popover のフォーカスリング指定を修正

### DIFF
--- a/frontend/style/object/project/_main.css
+++ b/frontend/style/object/project/_main.css
@@ -20,7 +20,9 @@
 	--_hide-button-padding: 6px;
 	--_hide-button-image-size: 24px;
 
-	outline: none;
+	&:focus {
+		outline: none;
+	}
 
 	&::part(content) {
 		outline-offset: -1px;


### PR DESCRIPTION
現状たまたま表示に問題はないが、潜在的なバグになりうる指定を修正